### PR TITLE
Add tests and OS X fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 *.swp
 *.*~
 CMakeLists.txt.user
+*.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
 script: 
   - make
   # test install/uninstall
+  - ctest --output-on-failure --build . -C ${TRAVIS_BUILD_TYPE}
   - sudo make install
 
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,11 @@ endif()
 # adding directories
 add_subdirectory(extern)
 add_subdirectory(src)
+
+
+# examples are also used as tests
+enable_testing()
+
 add_subdirectory(examples)
 
 

--- a/RTFConfig.cmake.in
+++ b/RTFConfig.cmake.in
@@ -56,6 +56,8 @@ endif()
 
 set(RTF_YARP_FOUND @RTF_HAS_YARP@)
 if(RTF_YARP_FOUND)
+  # todo: change to find_dependency when CMake 3.0 will be the minimum version
+  find_package(YARP QUIET)
   set_and_check(RTF_YARP_INCLUDEDIR "@PACKAGE_RTF_YARP_INCLUDEDIR@")
   list(APPEND RTF_LIBRARIES RTF::RTF_yarp_utility)
   list(APPEND RTF_INCLUDE_DIRS "${RTF_YARP_INCLUDEDIR}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,7 @@ if (BUILD_EXAMPLES)
 
     include_directories(${CMAKE_SOURCE_DIR}
                         ${RTF_TREE_INCLUDE_DIRS})
-     
+
 
     add_executable(rtf_simple simple.cpp)
     target_link_libraries(rtf_simple RTF)
@@ -20,10 +20,10 @@ if (BUILD_EXAMPLES)
             EXPORT  rtf_simple
             RUNTIME DESTINATION bin)
 
-    add_executable(rtf_simple_suit simple_suit.cpp)
-    target_link_libraries(rtf_simple_suit RTF)
-    install(TARGETS rtf_simple_suit
-            EXPORT  rtf_simple_suit
+    add_executable(rtf_simple_suite simple_suit.cpp)
+    target_link_libraries(rtf_simple_suite RTF)
+    install(TARGETS rtf_simple_suite
+            EXPORT  rtf_simple_suite
             RUNTIME DESTINATION bin)
 
     add_executable(rtf_simple_collector simple_collector.cpp)
@@ -50,6 +50,26 @@ if (BUILD_EXAMPLES)
         install(TARGETS rtf_simple_web
                 EXPORT  rtf_simple_web
                 RUNTIME DESTINATION bin)
+    endif()
+
+    # Examples are also used for regression testing
+    macro(add_example_as_failing_test examplename)
+        add_test(NAME Test::${examplename} COMMAND ${examplename})
+        # rtf examples are designed to explicitly fail (except for fixture test)
+        set_tests_properties(Test::${examplename} PROPERTIES WILL_FAIL true)
+    endmacro()
+
+    macro(add_example_as_successful_test examplename)
+        add_test(NAME Test::${examplename} COMMAND ${examplename})
+    endmacro()
+
+    add_example_as_failing_test(rtf_simple)
+    add_example_as_failing_test(rtf_simple_suite)
+    add_example_as_failing_test(rtf_simple_collector)
+    add_example_as_failing_test(rtf_simple_runner)
+    add_example_as_successful_test(rtf_simple_fixture)
+    if(ENABLE_WEB_LISTENER)
+        add_example_as_failing_test(rtf_simple_web)
     endif()
 
 endif(BUILD_EXAMPLES)

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -7,9 +7,11 @@
  *
  */
 
+#include <iostream>
 #include <stdio.h>
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
+#include <rtf/TestResultCollector.h>
 #include <rtf/ConsoleListener.h>
 #include <rtf/TestAssert.h>
 
@@ -46,17 +48,23 @@ public:
 int main(int argc, char** argv)
 {
     // create a test listener to collect the result
-    // and enbale the verbose mode
+    // and enable the verbose mode
     ConsoleListener listener(true);
+
+    // create a collector to get computer readable
+    // test results
+    TestResultCollector collector;
 
     // create a test result and add the listeners
     TestResult result;
     result.addListener(&listener);
+    result.addListener(&collector);
 
     // calling a test case
     MyTest atest;
     atest.TestCase::run(result);
 
-    return 0;
-
+    // return 0 if the test passed
+    // otherwise the number of failed test
+    return collector.failedCount();
 }

--- a/examples/simple_collector.cpp
+++ b/examples/simple_collector.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     result.addListener(&collector);
 
 
-    // create a test suit and the test cases
+    // create a test suite and the test cases
     TestSuit suit("MyTestSuit");
     MyTest1 test1;
     MyTest2 test2;
@@ -75,6 +75,8 @@ int main(int argc, char** argv)
     // store the results in a text file
     TextOutputter outputter(collector);
     outputter.write("./result.txt");
-    return 0;
+
+    // return the number of failed tests
+    return collector.failedCount();
 
 }

--- a/examples/simple_fixture.cpp
+++ b/examples/simple_fixture.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
+#include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
 #include <rtf/TestSuit.h>
 #include <rtf/FixtureManager.h>
@@ -72,9 +73,14 @@ int main(int argc, char** argv)
     // create a test listener to collect the result
     ConsoleListener listener(false);
 
+    // create a collector to get computer readable
+    // test results
+    TestResultCollector collector;
+
     // create a test result and add the listeners
     TestResult result;
     result.addListener(&listener);
+    result.addListener(&collector);
 
     // create a test suit
     TestSuit suit("MyTestSuit");
@@ -94,5 +100,6 @@ int main(int argc, char** argv)
     runner.addTest(&suit);
     runner.run(result);
 
-    return 0;
+    // return the number of failed tests
+    return collector.failedCount();
 }

--- a/examples/simple_runner.cpp
+++ b/examples/simple_runner.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
+#include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
 #include <rtf/ConsoleListener.h>
 #include <rtf/TestAssert.h>
@@ -48,9 +49,14 @@ int main(int argc, char** argv)
     // create a test listener to collect the result
     ConsoleListener listener(false);
 
+    // create a collector to get computer readable
+    // test results
+    TestResultCollector collector;
+
     // create a test result and add the listeners
     TestResult result;
     result.addListener(&listener);
+    result.addListener(&collector);
 
     // create a test runner
     TestRunner runner;
@@ -58,6 +64,7 @@ int main(int argc, char** argv)
     runner.addTest(&atest);
     runner.run(result);
 
-    return 0;
+    // return the number of failed tests
+    return collector.failedCount();
 
 }

--- a/examples/simple_suit.cpp
+++ b/examples/simple_suit.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
+#include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
 #include <rtf/TestSuit.h>
 #include <rtf/ConsoleListener.h>
@@ -43,9 +44,14 @@ int main(int argc, char** argv)
     // create a test listener to collect the result
     ConsoleListener listener(false);
 
+    // create a collector to get computer readable
+    // test results
+    TestResultCollector collector;
+
     // create a test result and add the listeners
     TestResult result;
     result.addListener(&listener);
+    result.addListener(&collector);
 
     // create a test suit and the test cases
     TestSuit suit("MyTestSuit");
@@ -59,6 +65,7 @@ int main(int argc, char** argv)
     runner.addTest(&suit);
     runner.run(result);
 
-    return 0;
+    // return the number of failed tests
+    return collector.failedCount();
 
 }

--- a/examples/simple_web.cpp
+++ b/examples/simple_web.cpp
@@ -13,6 +13,7 @@
 
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
+#include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
 #include <rtf/TestSuit.h>
 #include <rtf/WebProgressListener.h>
@@ -72,9 +73,14 @@ int main(int argc, char** argv)
     // create a test listener to collect the result
     WebProgressListener web(8080, false);
 
+    // create a collector to get computer readable
+    // test results
+    TestResultCollector collector;
+
     // create a test result sand add the listeners
     TestResult result;
     result.addListener(&web);
+    result.addListener(&collector);
     printf("To see the test result, open a web browser and type 'http://127.0.0.1:8080'...\n");
 
     // create a test suit and the test cases
@@ -88,5 +94,7 @@ int main(int argc, char** argv)
     TestRunner runner;
     runner.addTest(&suit);
     runner.run(result);
-    return 0;
+
+    // return the number of failed tests
+    return collector.failedCount();
 }

--- a/src/testrunner/include/PluginFactory.h
+++ b/src/testrunner/include/PluginFactory.h
@@ -86,12 +86,6 @@ public:
             if(PluginFactory::compare(ext.c_str(), ".so"))
                 return new RTF::plugin::DllPluginLoader();
         }
-        if(name.size() > 6) {
-            // check for mac .dylib
-            std::string ext = name.substr(name.size()-6,6);
-            if(PluginFactory::compare(ext.c_str(), ".dylib"))
-                return new RTF::plugin::DllPluginLoader();
-        }
         return NULL;
     }
 

--- a/src/testrunner/src/PluginRunner.cpp
+++ b/src/testrunner/src/PluginRunner.cpp
@@ -134,12 +134,6 @@ bool PluginRunner::loadPluginsFromPath(std::string path) {
             if(PluginFactory::compare(ext.c_str(), ".so"))
                 loadPlugin(path+name, 0);
         }
-        if(name.size() > 6) {
-            // check for mac .dylib
-            string ext = name.substr(name.size()-6,6);
-            if(PluginFactory::compare(ext.c_str(), ".dylib"))
-                loadPlugin(path+name, 0);
-        }
 #ifdef ENABLE_PYTHON_PLUGIN
         // check for .py
         if(name.size() > 2) {

--- a/src/testrunner/src/SuitRunner.cpp
+++ b/src/testrunner/src/SuitRunner.cpp
@@ -142,8 +142,6 @@ bool SuitRunner::loadSuit(std::string filename) {
                 if(PluginFactory::compare(test->Attribute("type"), "dll")) {
 #ifdef _WIN32
                    pluginName =  pluginName + ".dll";
-#elif __APPLE__
-                    pluginName =  pluginName + ".dylib";
 #else
                     pluginName =  pluginName + ".so";
 #endif

--- a/src/testrunner/src/SuitRunner.cpp
+++ b/src/testrunner/src/SuitRunner.cpp
@@ -111,8 +111,6 @@ bool SuitRunner::loadSuit(std::string filename) {
 
 #ifdef _WIN32
                 pluginName =  pluginName + ".dll";
-#elif __APPLE__
-                pluginName =  pluginName + ".dylib";
 #else
                 pluginName =  pluginName + ".so";
 #endif


### PR DESCRIPTION
* [ https://github.com/robotology/robot-testing/commit/d870eb3d064537fa6db9892ec14e0a01dd5eefa5 ] Search for YARP (if necessary) in the RTFConfig.cmake file 
* [ https://github.com/robotology/robot-testing/commit/bc89be40bcaa5748068f237f363fce76e96e9353 ] Run examples as tests
* [ https://github.com/robotology/robot-testing/commit/4bb14d3a426ab1e8289cee9da7fff53a5349ed2e ] On OS X the plugins (created with add_library(MODULE ...) ) end in .so, not .dylib .