### PR TITLE
[yarp] Fix regression in yarpmanager fixture manager

### DIFF
--- a/src/middleware/yarp/CMakeLists.txt
+++ b/src/middleware/yarp/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 2.8.9)
 
 project(RTF_yarp)
 
-find_package(YARP REQUIRED)
+find_package(YARP 2.3.64.14 REQUIRED)
 
 set_property(GLOBAL APPEND PROPERTY RTF_TREE_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)

--- a/src/middleware/yarp/fixture-ymanager/YarpFixManager.cpp
+++ b/src/middleware/yarp/fixture-ymanager/YarpFixManager.cpp
@@ -62,11 +62,12 @@ bool YarpFixManager::setup(int argc, char** argv) {
         enableRestrictedMode();
 
         // load the fixture (application xml)
-        char szAppName[] = "fixture";
-        ret = addApplication(appfile.c_str(), szAppName);
+        char szAppName[255];
+        ret = addApplication(appfile.c_str(), szAppName, 254);
         RTF_ASSERT_ERROR_IF(ret,
                             "yarpmanager (addApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
+
         ret = loadApplication(szAppName);
         RTF_ASSERT_ERROR_IF(ret,
                             "yarpmanager (loadApplication) cannot setup the fixture because " +


### PR DESCRIPTION
The regression was introduced by https://github.com/robotology/yarp/commit/4403ebbe380852d764df8eb33dab08eebec4d3a8
that changed the API of the manager-related yarp class, preventing to load any fixture using yarpmanager.

The fix was inspired by the similar pieces of code found in yarpmanager.

Bumping the required YARP version because we need a version of YARP
with the API with the latest change.