### PR TITLE
Fix project() VERSION issue on whole project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ include (GenerateExportHeader)
 set_property(GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
 set_property(GLOBAL PROPERTY RTF_LIBS)
 
-# add some internally used properties (not for intalling or exporting)
+# add some internally used properties (not for installing or exporting)
 set_property(GLOBAL PROPERTY RTF_INTERNAL_INCLUDE_DIRS)
 set_property(GLOBAL PROPERTY RTF_INTERNAL_LIBS)
 set_property(GLOBAL PROPERTY RTF_INTERNAL_DEFS)
@@ -90,8 +90,7 @@ set(INSTALL_RTF_YARP_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
 get_property(RTF_HAS_YARP GLOBAL PROPERTY RTF_HAS_YARP)
 
 
-
-install_basic_package_files(RTF
+install_basic_package_files(${PROJECT_NAME}
                             VERSION ${RTF_VERSION}
                             COMPATIBILITY AnyNewerVersion
                             TARGETS_PROPERTY RTF_LIBS

--- a/src/rtf/CMakeLists.txt
+++ b/src/rtf/CMakeLists.txt
@@ -5,9 +5,7 @@
 #  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 #
 
-project(RTF)
-
-set_property(GLOBAL APPEND PROPERTY RTF_TREE_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
+set_property(GLOBAL APPEND PROPERTY RTF_TREE_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
 get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
 get_property(RTF_INTERNAL_INCLUDE_DIRS GLOBAL PROPERTY RTF_INTERNAL_INCLUDE_DIRS)
 get_property(RTF_INTERNAL_LIBS GLOBAL PROPERTY RTF_INTERNAL_LIBS)
@@ -36,10 +34,10 @@ if(ENABLE_WEB_LISTENER)
         include/rtf/TextOutputter.h
         include/rtf/WebProgressListener.h)
 
-     set(RTF_HDRS_IMPL
+    set(RTF_HDRS_IMPL
         include/rtf/impl/WebProgressListener_impl.h)
 
-     set(RTF_SRCS
+    set(RTF_SRCS
         src/Arguments.cpp
         src/Asserter.cpp
         src/ConsoleListener.cpp
@@ -53,7 +51,7 @@ if(ENABLE_WEB_LISTENER)
         src/TextOutputter.cpp
         src/WebProgressListener.cpp)
 
-     include_directories(${PROJECT_SOURCE_DIR}/include/impl
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/impl
                         ${RTF_TREE_INCLUDE_DIRS}
                         ${RTF_INTERNAL_INCLUDE_DIRS})
 else()
@@ -77,9 +75,9 @@ else()
         include/rtf/TestSuit.h
         include/rtf/TextOutputter.h)
 
-     set(RTF_HDRS_IMPL )
+    set(RTF_HDRS_IMPL)
 
-     set(RTF_SRCS
+    set(RTF_SRCS
         src/Arguments.cpp
         src/Asserter.cpp
         src/ConsoleListener.cpp
@@ -92,34 +90,33 @@ else()
         src/TestSuit.cpp
         src/TextOutputter.cpp)
 
-     include_directories(${RTF_TREE_INCLUDE_DIRS}
+    include_directories(${RTF_TREE_INCLUDE_DIRS}
                         ${RTF_INTERNAL_INCLUDE_DIRS})
 endif()
 
-
 if(WIN32)
-    add_library(RTF STATIC ${RTF_SRCS} ${RTF_HDRS} ${RTF_HDRS_IMPL})
+    add_library(${PROJECT_NAME} STATIC ${RTF_SRCS} ${RTF_HDRS} ${RTF_HDRS_IMPL})
 else()
-    add_library(RTF SHARED ${RTF_SRCS} ${RTF_HDRS} ${RTF_HDRS_IMPL})
+    add_library(${PROJECT_NAME} SHARED ${RTF_SRCS} ${RTF_HDRS} ${RTF_HDRS_IMPL})
 endif()
 
 if(ENABLE_WEB_LISTENER)
-    target_link_libraries(RTF RTF_mongoose)
+    target_link_libraries(${PROJECT_NAME} RTF_mongoose)
 else()
-    target_link_libraries(RTF)
+    target_link_libraries(${PROJECT_NAME})
 endif()
 
-# choose which header files should be installed
-set_property(TARGET RTF PROPERTY PUBLIC_HEADER ${RTF_HDRS})
 
-install(TARGETS RTF
-        EXPORT RTF
+# choose which header files should be installed
+set_property(TARGET ${PROJECT_NAME} PROPERTY PUBLIC_HEADER ${RTF_HDRS})
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}
         COMPONENT runtime
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         PUBLIC_HEADER DESTINATION include/rtf)
 
-set_property(GLOBAL APPEND PROPERTY RTF_LIBS RTF)
-set_property(TARGET RTF PROPERTY INCLUDE_DIRS ${RTF_TREE_INCLUDE_DIRS})
-
+set_property(GLOBAL APPEND PROPERTY RTF_LIBS ${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME} PROPERTY INCLUDE_DIRS ${RTF_TREE_INCLUDE_DIRS})

--- a/src/testrunner/CMakeLists.txt
+++ b/src/testrunner/CMakeLists.txt
@@ -5,10 +5,8 @@
 #  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 #
 
-
 # cmake_minimum_required(VERSION 2.6)
-set(PROJECTNAME testrunner)
-project(${PROJECTNAME})
+project(testrunner)
 
 
 get_property(RTF_TREE_INCLUDE_DIRS GLOBAL PROPERTY RTF_TREE_INCLUDE_DIRS)
@@ -31,10 +29,9 @@ file(GLOB_RECURSE folder_header ./include/*.h)
 source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
-add_executable(${PROJECTNAME} ${folder_source} ${folder_header})
-target_link_libraries(${PROJECTNAME} ${RTF_LIBS} ${RTF_INTERNAL_LIBS} ${TinyXML_LIBRARIES})
+add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
+target_link_libraries(${PROJECT_NAME} ${RTF_LIBS} ${RTF_INTERNAL_LIBS} ${TinyXML_LIBRARIES})
 
-install(TARGETS ${PROJECTNAME}
-        EXPORT ${PROJECTNAME}
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}
         RUNTIME DESTINATION bin)
-


### PR DESCRIPTION
To avoid generating VERSION policy issue CMP0048 while configuring the project, the project root CMakeLists and the RTF CMakeLists have been modified.

In particular, in RTF's CMakeLists.txt the project(RTF) call has been removed because it was redundant and, by resetting the <PROJECT_NAME>_VERSION variables, the cause of the version policy issue.
As a consequence, several variable in RTF's CMakeLists.txt have been modified to account for the new path of the RTF project which is located in src/rtf/* folder, and not in the one where project(RTF) is originally defined.