### PR TITLE
Fix make warnings under macOS

### DIFF
--- a/src/rtf/src/Arguments.cpp
+++ b/src/rtf/src/Arguments.cpp
@@ -14,7 +14,6 @@
 #define C_MAXARGS           128         // max number of the command parametes
 
 using namespace RTF;
-using namespace std;
 
 void Arguments::split(char *line, char **args)
 {
@@ -34,7 +33,7 @@ void Arguments::split(char *line, char **args)
 }
 
 void Arguments::parse(char *azParam ,
-                               int *argc, char **argv)
+                      int *argc, char **argv)
 {
     char *pNext = azParam;
     size_t i;

--- a/src/testrunner/src/SuitRunner.cpp
+++ b/src/testrunner/src/SuitRunner.cpp
@@ -167,7 +167,7 @@ bool SuitRunner::loadSuit(std::string filename) {
                 if(test->Attribute("repetition")) {
                     char *endptr;
                     unsigned int rep = (unsigned int) strtol(test->Attribute("repetition"), &endptr, 10);
-                    if (endptr == 0 && rep >= 0) {
+                    if (endptr == 0) {
                         testcase->setRepetition(rep);
                     }
                     else {


### PR DESCRIPTION
While compiling RTF under macOS, two warnings were raised by the make process.
For details see #51.

This PR aims to remove the two warnings with two simple edits.

Please note that in [src/testrunner/src/SuitRunner.cpp#170](https://github.com/robotology/robot-testing/compare/master...claudiofantacci:fix/warnings?expand=1#diff-cf7b2907f15a74c75b3a2fa517aed67cL170) the `rep` variable is of type `unsigned int`, thus the `if` condition `rep >= 0` is always `true`.