### PR TITLE
YarpFixManager: fix after recent changes in libYARP_manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,24 +23,23 @@ before_install:
 install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew outdated cmake || brew upgrade cmake; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then if !  brew ls --versions python > /dev/null; then brew install python; fi; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install yarp; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install tinyxml lua51; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install tinyxml lua51 ace eigen; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y cmake libtinyxml-dev liblua5.1-dev python-dev libace-dev libeigen3-dev lcov; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo gem install coveralls-lcov; fi
   - python --version
 
 before_script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cd ..; fi
+  - cd ..
   # install yarp
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then git clone https://github.com/robotology/yarp; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cd yarp; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mkdir build; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cd build; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cmake -DCREATE_LIB_MATH:BOOL=ON -DCREATE_SHARED_LIBRARY:BOOL=ON -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE}  ..; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo make install; fi
+  - git clone https://github.com/robotology/yarp
+  - cd yarp
+  - mkdir build
+  - cd build
+  - cmake -DCREATE_LIB_MATH:BOOL=ON -DCREATE_SHARED_LIBRARY:BOOL=ON -DCMAKE_BUILD_TYPE=${TRAVIS_BUILD_TYPE}  ..
+  - make
+  - sudo make install
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo ldconfig; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cd ../../robot-testing; fi
+  - cd ../../robot-testing
 
 script:
   # configure robot-testing framework

--- a/src/middleware/yarp/fixture-ymanager/YarpFixManager.cpp
+++ b/src/middleware/yarp/fixture-ymanager/YarpFixManager.cpp
@@ -61,8 +61,8 @@ bool YarpFixManager::setup(int argc, char** argv) {
         enableRestrictedMode();
 
         // load the fixture (application xml)
-        char szAppName[255];
-        ret = addApplication(appfile.c_str(), szAppName, 254);
+        char* szAppName = YARP_NULLPTR;
+        ret = addApplication(appfile.c_str(), &szAppName, true);
         RTF_ASSERT_ERROR_IF(ret,
                             "yarpmanager (addApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
@@ -72,6 +72,11 @@ bool YarpFixManager::setup(int argc, char** argv) {
                             "yarpmanager (loadApplication) cannot setup the fixture because " +
                             std::string(getLogger()->getFormatedErrorString()));
         initialized = true;
+        if(szAppName)
+        {
+            delete [] szAppName;
+            szAppName = YARP_NULLPTR;
+        }
     }
 
     //run the modules and connect


### PR DESCRIPTION
This PR introduces the changes for making the `YarpFixManager` compatible after recent changes in `libYARP_manager`.
They are the same of robotology/yarp#1242
MERGE AFTER robotology/yarp#1244