### PR TITLE
Fix suit -> suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ test cases are developed as independent plug-ins (i.e., using scripting language
 loaded and executed by an automated test runner. Moreover, a fixture manager prepares the setup (e.g., running robot interfaces,
 simulator) and actively monitors that all the requirements for running the tests are satisfied during the execution of the tests.
 These functionalities along with other facilities such as the test result collector, result formatter and remote interface allow
-for rapid development of test units to cover different levels of system testing (see the block diagram). 
+for rapid development of test units to cover different levels of system testing (see the block diagram).
 
 ![rtf-arch](/doc/rtf_arch.png)
 
@@ -28,7 +28,7 @@ for rapid development of test units to cover different levels of system testing 
 Installation
 ------------
 RTF library does not depend on any external library. The RTF framework has a testrunner utility (see Running test case plug-ins
-using testrunner) to easily run the test cases which are built as plug-ins. Test cases can be organized in test suits using simple XML files. The testrunner uses TinyXml library for parsing the suit XML files. RTF build system check for the installation
+using testrunner) to easily run the test cases which are built as plug-ins. Test cases can be organized in test suites using simple XML files. The testrunner uses TinyXml library for parsing the suite XML files. RTF build system check for the installation
 of TinyXml and, in case, it cannot find any installed version of TinyXml library, it uses the internal version which is delivered
 with the RTF.
 
@@ -41,7 +41,7 @@ with the RTF.
     $ make install  # Optional!
 ```
 
-- **On Windows:** The installation is easy, straightforward and uses the CMake build system. Get [Cmake for windows](https://cmake.org/download/) if you have not yet installed. Then simply run the Cmake and, set the project (robot-testing) root folder and the desired build folder. Configure and generate project solution for your favorite IDE (e.g. Visual Studio 13). Then open the solution from your IDE and build the project.   
+- **On Windows:** The installation is easy, straightforward and uses the CMake build system. Get [Cmake for windows](https://cmake.org/download/) if you have not yet installed. Then simply run the Cmake and, set the project (robot-testing) root folder and the desired build folder. Configure and generate project solution for your favorite IDE (e.g. Visual Studio 13). Then open the solution from your IDE and build the project.
 
 Configuration
 -------------
@@ -59,16 +59,16 @@ The only thing you need to configure is the RTF_DIR environment variable so that
     C:\> setx.exe PATH "%PATH%;%RTF_DIR%/<Release/Debug>/bin"
 ```
 
-*Notice:* If you have **not** installed RTF in the statndard system path (e.g., on Linx without `make install`) then You need to exapnd your system `PATH` environment variable. 
+*Notice:* If you have **not** installed RTF in the statndard system path (e.g., on Linx without `make install`) then You need to exapnd your system `PATH` environment variable.
 
 
-Enabling Python, Ruby, Lua, ... Plugins 
+Enabling Python, Ruby, Lua, ... Plugins
 ----------------------------------------
-To use RTF with other languages, 
- - first you need to install their development packages (e.g. for Python on Linux you need `python-dev`, for Ruby: `ruby-dev` or for Lua: `liblua5.x-dev`). 
+To use RTF with other languages,
+ - first you need to install their development packages (e.g. for Python on Linux you need `python-dev`, for Ruby: `ruby-dev` or for Lua: `liblua5.x-dev`).
  - then you can enable the desired language into RTF Cmake (e.g. ENABLE_PYTHON_PLUGIN=ON for enabling python)
- - compile and build RTF 
- 
+ - compile and build RTF
+
 
 Tutorials and Examples
 -----------------------
@@ -81,7 +81,7 @@ Tutorials and Examples
 * [*Using Python plug-in to develop test cases.*](http://robotology.github.io/robot-testing/documentation/rtf_python_plugin_example.html)
 
 * [*Using Ruby plug-in to develop test cases.*](http://robotology.github.io/robot-testing/documentation/rtf_ruby_plugin_example.html)
- 
+
 * [*Running test case plug-ins using testrunner*](http://robotology.github.io/robot-testing/documentation/testrunner.html)
 
 

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -15,7 +15,7 @@
 RTF stands for Robot Testing Framework. It is a generic and multi-platform testing framework for the test driven development (TDD) which is initially designed for the robotic systems. However, it can be used for any TDD system. <br> The framework provides functionalities for developing and running unit tests in a language and middleware independent manner. The test cases are developed as independent plug-ins (i.e., using scripting languages or built as dynamically loadable libraries) to be loaded and executed by an automated test runner. Moreover, a fixture manager prepares the setup (e.g., running robot interfaces, simulator) and actively monitors that all the requirements for running the tests are satisfied during the execution of the tests. These  functionalities along with other facilities such as the test result collector, result formatter and remote interface allow for rapid development of test units to cover different levels of system testing.
 
 <br>
-\section Tutorials 
+\section Tutorials
 \li \ref rtf_plugin_example
 \li \ref rtf_lua_plugin_example
 \li \ref rtf_python_plugin_example
@@ -24,9 +24,9 @@ RTF stands for Robot Testing Framework. It is a generic and multi-platform testi
 
 <br>
 \section install Installation
-RTF library does not depend on any external library. The RTF framework has a \c testrunner utility (see \ref testrunner) to easily run the test cases which are built as plug-ins. Test cases can be organized in test suits using a simple XML files. The \c testrunner uses TinyXml library for parsing the suit XML files. RTF build system check for the installation of TinyXml and, in case, it cannot find any installed version of TinyXml library, it uses the internal version which is delivered with the RTF. The source code of the RTF is vailable at https://github.com/robotology/robot-testing. 
+RTF library does not depend on any external library. The RTF framework has a \c testrunner utility (see \ref testrunner) to easily run the test cases which are built as plug-ins. Test cases can be organized in test suites using a simple XML files. The \c testrunner uses TinyXml library for parsing the suite XML files. RTF build system check for the installation of TinyXml and, in case, it cannot find any installed version of TinyXml library, it uses the internal version which is delivered with the RTF. The source code of the RTF is vailable at https://github.com/robotology/robot-testing.
 
-\subsection compile Compile and Build 
+\subsection compile Compile and Build
 The installation is easy, straightforward and uses \c Cmake building system.
 \verbatim
     $ git clone https://github.com/robotology/robot-testing.git
@@ -35,21 +35,21 @@ The installation is easy, straightforward and uses \c Cmake building system.
     $ cmake ../; make
 \endverbatim
 
-and optionally: 
+and optionally:
 \verbatim
     $ make install
 \endverbatim
 
 
-\subsection conf Configuration 
-The only thing you need to configure is the RTF_DIR environment variable so that cmake can find RTF libraries and header files. 
+\subsection conf Configuration
+The only thing you need to configure is the RTF_DIR environment variable so that cmake can find RTF libraries and header files.
 
-For example on Linux/Mac: 
+For example on Linux/Mac:
 \verbatim
     $ echo 'export RTF_DIR=<path to the RTF build director>' >> ~/.bashrc
 \endverbatim
 
-Alternatively you can add the RTF \c 'bin' directory to your system PATH variable. 
+Alternatively you can add the RTF \c 'bin' directory to your system PATH variable.
 \verbatim
     $ echo 'export PATH=$PATH:<path to the RTF bin director>' >> ~/.bashrc
 \endverbatim
@@ -57,11 +57,11 @@ Alternatively you can add the RTF \c 'bin' directory to your system PATH variabl
 
 <br>
 \section example Running Examples
-There are some examples which are created by building RTF (The \c BUILD_EXAMPLES=ON should be enabled in the Cmake). After building the RTF, you can run these examples from \c build/bin directory. 
-\verbatim 
+There are some examples which are created by building RTF (The \c BUILD_EXAMPLES=ON should be enabled in the Cmake). After building the RTF, you can run these examples from \c build/bin directory.
+\verbatim
     $ cd build/bin
     $ ./simple
-    $ ./simle_suit
+    $ ./simple_suite
     $ ./simple_collector
     $ ...
 \endverbatim

--- a/doc/rtf_examples.dox
+++ b/doc/rtf_examples.dox
@@ -15,21 +15,21 @@ subdirectory of RTF.
 /**
  * \example simple.cpp
 
-This example shows a simple way of using TestCase, TestResult and ConsoleListener.  
+This example shows a simple way of using TestCase, TestResult and ConsoleListener.
 
 */
 
 /**
- * \example simple_suit.cpp
+ * \example simple_suite.cpp
 
-This example shows how to use a TestSuit to run multiple test cases. 
+This example shows how to use a TestSuite to run multiple test cases.
 
 */
 
 /**
  * \example simple_runner.cpp
 
-This example shows how to use a TestRunner to run the tests. 
+This example shows how to use a TestRunner to run the tests.
 
 */
 
@@ -37,7 +37,7 @@ This example shows how to use a TestRunner to run the tests.
 /**
  * \example simple_collector.cpp
 
-This example shows how to use a TestResultCollector to collect the result of the test run. 
+This example shows how to use a TestResultCollector to collect the result of the test run.
 
 */
 
@@ -45,7 +45,7 @@ This example shows how to use a TestResultCollector to collect the result of the
 /**
  * \example simple_fixture.cpp
 
-This example shows using a FixtureManager to setup any fixture required for a TestSuit.
+This example shows using a FixtureManager to setup any fixture required for a TestSuite.
 
 */
 

--- a/doc/testrunner.dox
+++ b/doc/testrunner.dox
@@ -13,20 +13,20 @@
 \li \ref desc
 \li \ref single
 \li \ref multiple
-\li \ref suit
-\li \ref single-suit
-\li \ref multiple-suit
+\li \ref suite
+\li \ref single-suite
+\li \ref multiple-suite
 \li \ref weblistener
 \li \ref stress-test
 \li \ref options
 
 <br>
 \section desc Description
-The \c testrunner is a command line tool to load and run multiple tests which has been developed as RTF plug-ins. The test case plug-ins are built as dynamic loadable libraries and depending on the target platform can be found as \c *.so, \c *.dll or *.dylib or using Lua, Python, Ruby and other scripting languages (e.g., .lua, .py, .rb). The \c testrunner can be used to run a single test case, multiple test cases from a given path, a \ref suit or multiple test suits from a given path.  
+The \c testrunner is a command line tool to load and run multiple tests which has been developed as RTF plug-ins. The test case plug-ins are built as dynamic loadable libraries and depending on the target platform can be found as \c *.so, \c *.dll or *.dylib or using Lua, Python, Ruby and other scripting languages (e.g., .lua, .py, .rb). The \c testrunner can be used to run a single test case, multiple test cases from a given path, a \ref suite or multiple test suites from a given path.
 
 <br>
-\section single Running a single test case  
-To run a single test case plug-in, it is enough to give the name of the corresponding plug-ing file to the \c testrunner using \c --test option. For example on a Linux machine:  
+\section single Running a single test case
+To run a single test case plug-in, it is enough to give the name of the corresponding plug-ing file to the \c testrunner using \c --test option. For example on a Linux machine:
 
 \verbatim
  $ testrunner --verbose --test libmytest.so
@@ -38,7 +38,7 @@ The \c testrunner follows the platform policy to look for the plug-in file. On a
  $ testrunner --verbose --test ~/my-plugins/libmytest.so
 \endverbatim
 
-In the similar way you can run a test case which has been developed using Lua, Python, Ruby or other languages: 
+In the similar way you can run a test case which has been developed using Lua, Python, Ruby or other languages:
 
 \verbatim
  $ testrunner --verbose --test ~/my-plugins/mytest.lua
@@ -46,26 +46,26 @@ In the similar way you can run a test case which has been developed using Lua, P
  $ testrunner --verbose --test ~/my-plugins/mytest.rb
 \endverbatim
 
-The \c `--verbose` enables the verbose mode which allows that the result of the tests to be also written to the standard out put. By default the result of the test are stored in the \c `result.txt` which can be changed by using \c `--output` option. 
+The \c `--verbose` enables the verbose mode which allows that the result of the tests to be also written to the standard out put. By default the result of the test are stored in the \c `result.txt` which can be changed by using \c `--output` option.
 
 <br>
-\section multiple Running all test cases from a given path 
-Multiple test cases can be easily loaded and run using \c `--tests` option. The expected value for this option is a directory where test case plug-ins are stored.  
+\section multiple Running all test cases from a given path
+Multiple test cases can be easily loaded and run using \c `--tests` option. The expected value for this option is a directory where test case plug-ins are stored.
 
 \verbatim
  $ testrunner --verbose --tests ~/my-plugins
 \endverbatim
 
-If the \c `--recursive` switch is given with the \c `--tests` option, the sub-folders are also searched for plug-ins. 
+If the \c `--recursive` switch is given with the \c `--tests` option, the sub-folders are also searched for plug-ins.
 
 <br>
-\section suit Test suit
-By definition, a test suit is a set of test cases which share the same test fixture. In RTF a set of test cases (plug-ins) can be grouped in a test suit using a XML file. Here is an example of test suit:
+\section suite Test suite
+By definition, a test suite is a set of test cases which share the same test fixture. In RTF a set of test cases (plug-ins) can be grouped in a test suite using a XML file. Here is an example of test suite:
 
 \htmlonly
 <!-- HTML generated using hilite.me --><div style="background: #ffffff; overflow:auto;width:auto;border:solid gray;border-width:.1em .1em .1em .8em;padding:.2em .6em;"><pre style="margin: 0; line-height: 125%"><span style="color: #557799">&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;</span>
 
-<span style="color: #007700">&lt;suit</span> <span style="color: #0000CC">name=</span><span style="background-color: #fff0f0">&quot;my suit&quot;</span><span style="color: #007700">&gt;</span>
+<span style="color: #007700">&lt;suite</span> <span style="color: #0000CC">name=</span><span style="background-color: #fff0f0">&quot;my suite&quot;</span><span style="color: #007700">&gt;</span>
     <span style="color: #007700">&lt;description&gt;</span> a simple example <span style="color: #007700">&lt;/description&gt;</span>
     <span style="color: #007700">&lt;environment&gt;</span> --robot simulator <span style="color: #007700">&lt;/environment&gt;</span>
     <span style="color: #007700">&lt;fixture</span> <span style="color: #0000CC">param=</span><span style="background-color: #fff0f0">&quot;--from myfixture.ini&quot;</span><span style="color: #007700">&gt;</span> libfixture.so <span style="color: #007700">&lt;/fixture&gt;</span>
@@ -78,52 +78,52 @@ By definition, a test suit is a set of test cases which share the same test fixt
     <span style="color: #007700">&lt;test</span> <span style="color: #0000CC">param=</span><span style="background-color: #fff0f0">&quot;&quot;</span><span style="color: #007700">&gt;</span> ~/mytest/test4.py <span style="color: #007700">&lt;/test&gt;</span>
     <span style="color: #007700">&lt;test</span> <span style="color: #0000CC">param=</span><span style="background-color: #fff0f0">&quot;&quot;</span><span style="color: #007700">&gt;</span> ~/mytest/test5.rb <span style="color: #007700">&lt;/test&gt;</span>
     ...
-<span style="color: #007700">&lt;/suit&gt;</span>
+<span style="color: #007700">&lt;/suite&gt;</span>
 </pre></div>
 \endhtmlonly
 
-The example demonstrates a test suit which includes two test cases (\c libmytest1.so and \c libmytest2.so). An optional string parameter can be also specified for each test using \c param attribute in the \c test tag. ​The parameter string is parsed into (argc/argv) format and will be passed to the test case using RTF::TestCase::setup(int argc, char** argv). Alternatively, the raw value of the parameter can be access in the test plug-in implementation using RTF::TestCase::getParam method.
+The example demonstrates a test suite which includes two test cases (\c libmytest1.so and \c libmytest2.so). An optional string parameter can be also specified for each test using \c param attribute in the \c test tag. ​The parameter string is parsed into (argc/argv) format and will be passed to the test case using RTF::TestCase::setup(int argc, char** argv). Alternatively, the raw value of the parameter can be access in the test plug-in implementation using RTF::TestCase::getParam method.
 
 The environment can be used in the implementation of the test cases to know in which setup (e.g., simulation, real world environment) the test case is employed. The environment value can also be accessed in the test plug-in implementation using RTF::TestCase::getEnvironment method.
 
-If a fixture manager plug-in is specified using \c <fixture> tag, it will be loaded by the \c testrunner and is set for the current test suit. When suit is executed, the fixture manager will be called automatically to setup and monitor the test fixture which is implemented in the fixture plug-in. (Please see the \c examples/fixture-plugin folder for an example of implementing fixture plug-ins.) 
- 
+If a fixture manager plug-in is specified using \c <fixture> tag, it will be loaded by the \c testrunner and is set for the current test suite. When suite is executed, the fixture manager will be called automatically to setup and monitor the test fixture which is implemented in the fixture plug-in. (Please see the \c examples/fixture-plugin folder for an example of implementing fixture plug-ins.)
+
 Notice that, for \c libtest2.so,  a complete path to the plug-in file is given. Thus, the \c testrunner does not look into system default paths (e.g., LD_LIBRARY_PATH) for the plug-in file and it expects to find the plug-in file using the given path. However, this is not the case for \c libtest1.so.
 
-The `testrunner` usually checks for the extension of the plug-in file name to recognize the type of the plug-in. There is also possibility to explicitly indicate the type of the plug-in using the `type` attribute. For example if `type="dll"`, then the plug-in test should be given without the extension. Depending on which platform (Windows, Linux or Mac) the test is running, the `testrunner` looks for the correct (shared library) plug-in name (.dll, .so or .dylib). 
+The `testrunner` usually checks for the extension of the plug-in file name to recognize the type of the plug-in. There is also possibility to explicitly indicate the type of the plug-in using the `type` attribute. For example if `type="dll"`, then the plug-in test should be given without the extension. Depending on which platform (Windows, Linux or Mac) the test is running, the `testrunner` looks for the correct (shared library) plug-in name (.dll, .so or .dylib).
 
 <br>
-\section single-suit Running a single test suit
-A single test suit (XML file) can be run using \c `--suit` option. For example:
+\section single-suite Running a single test suite
+A single test suite (XML file) can be run using \c `--suite` option. For example:
 \verbatim
- $ testrunner --verbose --suit ~/my-suits/suit.xml
+ $ testrunner --verbose --suite ~/my-suites/suite.xml
 \endverbatim
 
 <br>
-\section multiple-suit Running multiple test suits
-Multiple test suits can be loaded and rune using \c `--suits` option. The expected value for this option is a directory where test suits (XML files) are stored.  
+\section multiple-suite Running multiple test suites
+Multiple test suites can be loaded and rune using \c `--suites` option. The expected value for this option is a directory where test suites (XML files) are stored.
 
 \verbatim
- $ testrunner --verbose --suits ~/my-suits
+ $ testrunner --verbose --suites ~/my-suites
 \endverbatim
 
-If the \c `--recursive` switch is given with the \c `--suits` option, the sub-folders are also searched for test suits. 
+If the \c `--recursive` switch is given with the \c `--suites` option, the sub-folders are also searched for test suites.
 
 <br>
 \section weblistener Monitoring tests from your browser
-The `testrunner` uses RTF::WebProgressListener to provide a simple web server which allows you to monitor the test's running progress from a browser. To do that, you need to run a test/suite by the `testrunner` using `--web-reporter` option.  
+The `testrunner` uses RTF::WebProgressListener to provide a simple web server which allows you to monitor the test's running progress from a browser. To do that, you need to run a test/suite by the `testrunner` using `--web-reporter` option.
 
 \verbatim
- $ testrunner --web-reporter --verbose --suits ~/my-suits
+ $ testrunner --web-reporter --verbose --suites ~/my-suites
 \endverbatim
 
-Then open a web browser and type `http://127.0.0.1:8080` or the remote address where the `testrunner` has been launched. You can also change the `testrunner` default port by using `--web-port <port number>` option. 
+Then open a web browser and type `http://127.0.0.1:8080` or the remote address where the `testrunner` has been launched. You can also change the `testrunner` default port by using `--web-port <port number>` option.
 
-Notice that, the web reporting functionality may not be available by default and you need to enable it when building the RTF by turning on the `ENABLE_WEB_LISTENER` from the cmake. 
+Notice that, the web reporting functionality may not be available by default and you need to enable it when building the RTF by turning on the `ENABLE_WEB_LISTENER` from the cmake.
 
 <br>
 \section stress-test Using RTF for stress testing
-For stress testing, it is possible to repeat a test case for desired iterations. This can be easily done by providing the number of the test runs as the parameter (e.g., `--repetition 5`) for the `testrunner` or setting as the attribute of the test case within a test suite XML file. The `testrunner` repeats running the test for the desired iterations if the test does not fail. Notice that, only the `RTF::TestCase::run()` will be called repeatedly.   
+For stress testing, it is possible to repeat a test case for desired iterations. This can be easily done by providing the number of the test runs as the parameter (e.g., `--repetition 5`) for the `testrunner` or setting as the attribute of the test case within a test suite XML file. The `testrunner` repeats running the test for the desired iterations if the test does not fail. Notice that, only the `RTF::TestCase::run()` will be called repeatedly.
 
 \verbatim
  $ testrunner --verbose --test ~/my-plugins/mytest.lua --repetition 5
@@ -132,16 +132,16 @@ For stress testing, it is possible to repeat a test case for desired iterations.
 
 
 <br>
-\section options The testrunner options  
-Here is the full list of \c testrunner options: 
+\section options The testrunner options
+Here is the full list of \c testrunner options:
 
 \verbatim
-usage: testrunner [options] ... 
+usage: testrunner [options] ...
 options:
   -t, --test            Runs a single test from the given plugin file. (string [=])
       --tests           Runs multiple tests from the given folder which contains plugins. (string [=])
-  -s, --suit            Runs a single test suit from the given XMl file. (string [=])
-      --suits           Runs multiple test suits from the given folder which contains XML files. (string [=])
+  -s, --suite           Runs a single test suite from the given XMl file. (string [=])
+      --suites          Runs multiple test suites from the given folder which contains XML files. (string [=])
   -o, --output          The output file to save the result. Default is result.txt (string [=])
       --output-type     The output file type (text, junit) (string [=text])
   -p, --param           Sets the test case parameters. (Can be used only with --test option.) (string [=])
@@ -149,13 +149,13 @@ options:
       --repetition      Sets the test run repetition. (Can be used only with --test option.) (j [=0])
   -w, --web-reporter    Enables web reporter
       --web-port        Sets the web reporter server port. (The default port number is 8080.) (i [=8080])
-  -r, --recursive       Searches into subfolders for plugins or XML files. (Can be used with --tests or --suits options.)
+  -r, --recursive       Searches into subfolders for plugins or XML files. (Can be used with --tests or --suites options.)
   -d, --detail          Enables verbose mode of test assertions.
   -v, --verbose         Enables verbose mode.
       --version         Shows version information.
   -?, --help            print this message
 \endverbatim
-  
+
 \author Ali Paikan
 
 */

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,7 +20,7 @@ if (BUILD_EXAMPLES)
             EXPORT  rtf_simple
             RUNTIME DESTINATION bin)
 
-    add_executable(rtf_simple_suite simple_suit.cpp)
+    add_executable(rtf_simple_suite simple_suite.cpp)
     target_link_libraries(rtf_simple_suite RTF)
     install(TARGETS rtf_simple_suite
             EXPORT  rtf_simple_suite

--- a/examples/fixture-plugin/test.cpp
+++ b/examples/fixture-plugin/test.cpp
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/ConsoleListener.h>
 #include <rtf/TestRunner.h>
 #include <rtf/TestAssert.h>
@@ -33,11 +33,11 @@ public:
 
 int main(int argc, char *argv[]) {
 
-	if(argc < 2) {
+    if(argc < 2) {
         printf("Usage: %s <fixcture manager plugin file name>\n", argv[0]);
         printf("for example: %s libmyfixture.so\n", argv[0]);
-		return 0;
-	}
+        return 0;
+    }
 
     // load the test case plugin
     printf("Loading the fixture manager plugin... \n");
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
     if(fixture == NULL) {
         printf("%s\n", loader.getLastError().c_str());
         return 0;
-	}
+    }
 
     // create a test listener to collect the result
     ConsoleListener listener(false);
@@ -55,19 +55,19 @@ int main(int argc, char *argv[]) {
     TestResult result;
     result.addListener(&listener);
 
-    // create a test suit
-    TestSuit suit("MyTestSuit");
+    // create a test suite
+    TestSuite suite("MyTestSuite");
 
-    // set the fixture manager for the test suit
-    suit.setFixtureManager(fixture);
+    // set the fixture manager for the test suite
+    suite.setFixtureManager(fixture);
 
-    // creates test cases and add them to the suit
+    // creates test cases and add them to the suite
     MyTest1 test1;
-    suit.addTest(&test1);
+    suite.addTest(&test1);
 
     // create a test runner and run the tests
     TestRunner runner;
-    runner.addTest(&suit);
+    runner.addTest(&suite);
     runner.run(result);
 
     return 0;

--- a/examples/lua-plugin/run.cpp
+++ b/examples/lua-plugin/run.cpp
@@ -21,11 +21,11 @@ using namespace RTF::plugin;
 
 int main(int argc, char *argv[]) {
 
-	if(argc < 2) {
+    if(argc < 2) {
         printf("Usage: %s <lua plugin file name>\n", argv[0]);
         printf("for example: %s mytest.lua\n", argv[0]);
-		return 0;
-	}
+        return 0;
+    }
 
     // load the test case plugin
     printf("Loading the plugin... \n");
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     if(test == NULL) {
         printf("%s\n", loader.getLastError().c_str());
         return 0;
-	}
+    }
 
     // create a test listener to collect the result
     ConsoleListener listener(false);

--- a/examples/plugin/run.cpp
+++ b/examples/plugin/run.cpp
@@ -21,11 +21,11 @@ using namespace RTF::plugin;
 
 int main(int argc, char *argv[]) {
 
-	if(argc < 2) {
+    if(argc < 2) {
         printf("Usage: %s <plugin file name>\n", argv[0]);
         printf("for example: %s libmytest.so\n", argv[0]);
-		return 0;
-	}
+        return 0;
+    }
 
     // load the test case plugin
     printf("Loading the plugin... \n");
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     if(test == NULL) {
         printf("%s\n", loader.getLastError().c_str());
         return 0;
-	}
+    }
 
     // create a test listener to collect the result
     ConsoleListener listener(false);

--- a/examples/python-plugin/run.cpp
+++ b/examples/python-plugin/run.cpp
@@ -21,11 +21,11 @@ using namespace RTF::plugin;
 
 int main(int argc, char *argv[]) {
 
-	if(argc < 2) {
+    if(argc < 2) {
         printf("Usage: %s <pyhton plugin file name>\n", argv[0]);
         printf("for example: %s mytest.py\n", argv[0]);
-		return 0;
-	}
+        return 0;
+    }
 
     // load the test case plugin
     printf("Loading the plugin... \n");
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     if(test == NULL) {
         printf("%s\n", loader.getLastError().c_str());
         return 0;
-	}
+    }
 
     // create a test listener to collect the result
     ConsoleListener listener(false);

--- a/examples/ruby-plugin/run.cpp
+++ b/examples/ruby-plugin/run.cpp
@@ -21,11 +21,11 @@ using namespace RTF::plugin;
 
 int main(int argc, char *argv[]) {
 
-	if(argc < 2) {
+    if(argc < 2) {
         printf("Usage: %s <ruby plugin file name>\n", argv[0]);
         printf("for example: %s mytest.rb\n", argv[0]);
-		return 0;
-	}
+        return 0;
+    }
 
     // load the test case plugin
     printf("Loading the plugin... \n");
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     if(test == NULL) {
         printf("%s\n", loader.getLastError().c_str());
         return 0;
-	}
+    }
 
     // create a test listener to collect the result
     ConsoleListener listener(false);

--- a/examples/simple_collector.cpp
+++ b/examples/simple_collector.cpp
@@ -11,7 +11,7 @@
 #include <rtf/TestCase.h>
 #include <rtf/TestResult.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/ConsoleListener.h>
 #include <rtf/TestAssert.h>
 #include <rtf/TestResultCollector.h>
@@ -55,15 +55,15 @@ int main(int argc, char** argv)
 
 
     // create a test suite and the test cases
-    TestSuit suit("MyTestSuit");
+    TestSuite suite("MyTestSuite");
     MyTest1 test1;
     MyTest2 test2;
-    suit.addTest(&test1);
-    suit.addTest(&test2);
+    suite.addTest(&test1);
+    suite.addTest(&test2);
 
     // create a test runner
     TestRunner runner;
-    runner.addTest(&suit);
+    runner.addTest(&suite);
     runner.run(result);
 
     // print out some simple statistics

--- a/examples/simple_fixture.cpp
+++ b/examples/simple_fixture.cpp
@@ -12,7 +12,7 @@
 #include <rtf/TestResult.h>
 #include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/FixtureManager.h>
 #include <rtf/ConsoleListener.h>
 #include <rtf/TestAssert.h>
@@ -82,22 +82,22 @@ int main(int argc, char** argv)
     result.addListener(&listener);
     result.addListener(&collector);
 
-    // create a test suit
-    TestSuit suit("MyTestSuit");
+    // create a test suite
+    TestSuite suite("MyTestSuite");
 
     // create a fixture manager for the test suit
-    MyFixture fixture(&suit);
-    suit.addFixtureManager(&fixture);
+    MyFixture fixture(&suite);
+    suite.addFixtureManager(&fixture);
 
     // creates test cases and add them to the suit
     MyTest1 test1;
     MyTest2 test2;
-    suit.addTest(&test1);
-    suit.addTest(&test2);
+    suite.addTest(&test1);
+    suite.addTest(&test2);
 
     // create a test runner and run the tests
     TestRunner runner;
-    runner.addTest(&suit);
+    runner.addTest(&suite);
     runner.run(result);
 
     // return the number of failed tests

--- a/examples/simple_suite.cpp
+++ b/examples/simple_suite.cpp
@@ -12,7 +12,7 @@
 #include <rtf/TestResult.h>
 #include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/ConsoleListener.h>
 #include <rtf/TestAssert.h>
 
@@ -53,16 +53,16 @@ int main(int argc, char** argv)
     result.addListener(&listener);
     result.addListener(&collector);
 
-    // create a test suit and the test cases
-    TestSuit suit("MyTestSuit");
+    // create a test suite and the test cases
+    TestSuite suite("MyTestSuite");
     MyTest1 test1;
     MyTest2 test2;
-    suit.addTest(&test1);
-    suit.addTest(&test2);
+    suite.addTest(&test1);
+    suite.addTest(&test2);
 
     // create a test runner
     TestRunner runner;
-    runner.addTest(&suit);
+    runner.addTest(&suite);
     runner.run(result);
 
     // return the number of failed tests

--- a/examples/simple_web.cpp
+++ b/examples/simple_web.cpp
@@ -15,12 +15,12 @@
 #include <rtf/TestResult.h>
 #include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/WebProgressListener.h>
 #include <rtf/TestAssert.h>
 
 #ifdef _WIN32
-	#include <Windows.h>
+    #include <Windows.h>
 #else
     #include <unistd.h>
 #endif
@@ -32,10 +32,10 @@ public:
     MyTest1() : TestCase("MyTest1") { }
 
     virtual void run() {
-		srand(time(NULL));
+        srand(time(NULL));
         for (int i=0; i< 10; i++) {
-			int a = rand() % 10;
-			int b = rand() % 10;
+            int a = rand() % 10;
+            int b = rand() % 10;
             RTF_TEST_REPORT("testing smaller...");
             RTF_TEST_FAIL_IF(a<b, "is not smaller");
 #ifdef _WIN32
@@ -52,10 +52,10 @@ public:
     MyTest2() : TestCase("MyTest2") { }
 
     virtual void run() {
-		srand(time(NULL));
+        srand(time(NULL));
         for (int i=0; i< 10; i++) {
-			int a = rand() % 10;
-			int b = rand() % 10;
+            int a = rand() % 10;
+            int b = rand() % 10;
             RTF_TEST_REPORT("testing equality...");
             RTF_TEST_FAIL_IF(a==b, "are not equal");
 #ifdef _WIN32
@@ -63,7 +63,7 @@ public:
 #else
             sleep(1);
 #endif
-		}
+        }
     }
 };
 
@@ -83,16 +83,16 @@ int main(int argc, char** argv)
     result.addListener(&collector);
     printf("To see the test result, open a web browser and type 'http://127.0.0.1:8080'...\n");
 
-    // create a test suit and the test cases
-    TestSuit suit("MyTestSuit");
+    // create a test suite and the test cases
+    TestSuite suite("MyTestSuite");
     MyTest1 test1;
     MyTest2 test2;
-    suit.addTest(&test1);
-    suit.addTest(&test2);
+    suite.addTest(&test1);
+    suite.addTest(&test2);
 
     // create a test runner
     TestRunner runner;
-    runner.addTest(&suit);
+    runner.addTest(&suite);
     runner.run(result);
 
     // return the number of failed tests

--- a/examples/testrunner/mysuite.xml
+++ b/examples/testrunner/mysuite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suit name="my suit">
-    <description> a simple suit example</description>
+<suite name="my suite">
+    <description> a simple suite example</description>
     <environment></environment>
 
     <test param=""> libmytest.so </test>
     <!-- you can add more test here... -->
-</suit>
+</suite>
 

--- a/src/plugins/dll/include/rtf/dll/rtf_dll_config.h
+++ b/src/plugins/dll/include/rtf/dll/rtf_dll_config.h
@@ -12,8 +12,8 @@
 #define _SHLIBPP_CONFIG_
 
 #if defined(WIN32)
-#	define SHLIBPP_FILTER_API
-#endif 
+#    define SHLIBPP_FILTER_API
+#endif
 
 #if defined _WIN32 || defined __CYGWIN__
 #  define SHLIBPP_HELPER_DLL_IMPORT __declspec(dllimport)

--- a/src/plugins/dll/src/SharedLibrary.cpp
+++ b/src/plugins/dll/src/SharedLibrary.cpp
@@ -38,17 +38,17 @@ bool SharedLibrary::open(const char *filename) {
     close();
 #if defined(WIN32)
     implementation = (void*)LoadLibrary(filename);
-	LPTSTR msg = NULL;
-	FormatMessage(
-	   FORMAT_MESSAGE_FROM_SYSTEM |FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
-	   NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-	   (LPTSTR)&msg, 0, NULL);
+    LPTSTR msg = NULL;
+    FormatMessage(
+       FORMAT_MESSAGE_FROM_SYSTEM |FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+       NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+       (LPTSTR)&msg, 0, NULL);
 
-	if(msg != NULL) {
-		err_message = std::string(msg);
-	   // release memory allocated by FormatMessage()
-	   LocalFree(msg); msg = NULL;
-	}
+    if(msg != NULL) {
+        err_message = std::string(msg);
+       // release memory allocated by FormatMessage()
+       LocalFree(msg); msg = NULL;
+    }
     return (implementation != NULL);
 #else
     implementation = dlopen(filename, RTLD_LAZY);
@@ -76,18 +76,18 @@ void *SharedLibrary::getSymbol(const char *symbolName) {
     if (implementation==NULL) return NULL;
 #if defined(WIN32)
     FARPROC proc = GetProcAddress((HINSTANCE)implementation, symbolName);
-	LPTSTR msg = NULL;
-	FormatMessage(
-	   FORMAT_MESSAGE_FROM_SYSTEM |FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
-	   NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-	   (LPTSTR)&msg, 0, NULL);
+    LPTSTR msg = NULL;
+    FormatMessage(
+       FORMAT_MESSAGE_FROM_SYSTEM |FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+       NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+       (LPTSTR)&msg, 0, NULL);
 
-	if(msg != NULL) {
-		err_message = std::string(msg);
-	   // release memory allocated by FormatMessage()
-	   LocalFree(msg); msg = NULL;
-	}
-	return (void*)proc;
+    if(msg != NULL) {
+        err_message = std::string(msg);
+       // release memory allocated by FormatMessage()
+       LocalFree(msg); msg = NULL;
+    }
+    return (void*)proc;
 #else
     dlerror();
     void* func = dlsym(implementation,symbolName);

--- a/src/plugins/python/src/PythonPluginLoader.cpp
+++ b/src/plugins/python/src/PythonPluginLoader.cpp
@@ -80,18 +80,18 @@ TestCase* PythonPluginLoaderImpl::open(const std::string filename) {
     // extending python system path
 #ifdef _WIN32
 
-	char drive[_MAX_DRIVE];
-	char dir[_MAX_DIR];
-	char fname[_MAX_FNAME];
-	char ext[_MAX_EXT];
-	_splitpath_s(filename.c_str(), 
-				 drive, _MAX_DRIVE,
-				 dir, _MAX_DIR, 
-				 fname, _MAX_FNAME,
-				 ext, _MAX_EXT);
+    char drive[_MAX_DRIVE];
+    char dir[_MAX_DIR];
+    char fname[_MAX_FNAME];
+    char ext[_MAX_EXT];
+    _splitpath_s(filename.c_str(),
+                 drive, _MAX_DRIVE,
+                 dir, _MAX_DIR,
+                 fname, _MAX_FNAME,
+                 ext, _MAX_EXT);
     string dname = string(drive) + string(dir);
-	for(size_t i=0; i<dname.size(); i++)
-		dname[i] = (dname[i] == '\\') ? '/' : dname[i];
+    for(size_t i=0; i<dname.size(); i++)
+        dname[i] = (dname[i] == '\\') ? '/' : dname[i];
     string bname = fname;
 #else
     char* dir = strdup(filename.c_str());

--- a/src/rtf/CMakeLists.txt
+++ b/src/rtf/CMakeLists.txt
@@ -30,7 +30,7 @@ if(ENABLE_WEB_LISTENER)
         include/rtf/TestResultCollector.h
         include/rtf/TestResult.h
         include/rtf/TestRunner.h
-        include/rtf/TestSuit.h
+        include/rtf/TestSuite.h
         include/rtf/TextOutputter.h
         include/rtf/WebProgressListener.h)
 
@@ -47,7 +47,7 @@ if(ENABLE_WEB_LISTENER)
         src/TestResultCollector.cpp
         src/TestResult.cpp
         src/TestRunner.cpp
-        src/TestSuit.cpp
+        src/TestSuite.cpp
         src/TextOutputter.cpp
         src/WebProgressListener.cpp)
 
@@ -72,7 +72,7 @@ else()
         include/rtf/TestResultCollector.h
         include/rtf/TestResult.h
         include/rtf/TestRunner.h
-        include/rtf/TestSuit.h
+        include/rtf/TestSuite.h
         include/rtf/TextOutputter.h)
 
     set(RTF_HDRS_IMPL)
@@ -87,7 +87,7 @@ else()
         src/TestResultCollector.cpp
         src/TestResult.cpp
         src/TestRunner.cpp
-        src/TestSuit.cpp
+        src/TestSuite.cpp
         src/TextOutputter.cpp)
 
     include_directories(${RTF_TREE_INCLUDE_DIRS}

--- a/src/rtf/include/rtf/Asserter.h
+++ b/src/rtf/include/rtf/Asserter.h
@@ -15,7 +15,7 @@
 #include <rtf/Exception.h>
 #include <rtf/TestMessage.h>
 #include <rtf/TestCase.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 
 namespace RTF {
     class Asserter;
@@ -68,11 +68,11 @@ public:
      * @brief report report a message to the
      * result collector of the given TestSuit
      * @param msg The corresponding message
-     * @param testsuit The owner of the message (reporter)
+     * @param testsuite The owner of the message (reporter)
      * @note report does not throw any exception!
      */
     static RTF_API void report(RTF::TestMessage msg,
-                        RTF::TestSuit* testsuit);
+                        RTF::TestSuite* testsuite);
 
     /**
      * @brief report report a message to the

--- a/src/rtf/include/rtf/ConsoleListener.h
+++ b/src/rtf/include/rtf/ConsoleListener.h
@@ -86,16 +86,16 @@ public:
     virtual void endTest(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is started
+     * This is called when a TestSuite is started
      * @param test pointer to the corresponding test
      */
-    virtual void startTestSuit(const RTF::Test* test);
+    virtual void startTestSuite(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is finished
+     * This is called when a TestSuite is finished
      * @param test pointer to the corresponding test
      */
-    virtual void endTestSuit(const RTF::Test* test);
+    virtual void endTestSuite(const RTF::Test* test);
 
     /**
      * This is called when the TestRunner is started

--- a/src/rtf/include/rtf/FixtureManager.h
+++ b/src/rtf/include/rtf/FixtureManager.h
@@ -29,7 +29,7 @@ class RTF::FixtureEvents {
 public:
     /**
      * @brief fixtureCollapsed is called by a fixture manager
-     *        to inform the test suit that the corresponding
+     *        to inform the test suite that the corresponding
      *        fixture has been collapsed.
      * @param reason An error message indicates the reason for
      *        collapsing the fixture.
@@ -42,7 +42,7 @@ public:
  * \ingroup key_class
  *
  * \brief The FixtureManager can be used to to setup any fixture which
- * is required for the tests before executing the tests by a TestSuit.
+ * is required for the tests before executing the tests by a TestSuite.
  *
  * The \c fixtureCollapsed method of the FixtureEvents class is used by a
  * fixture manager to inform any class  which inherited from FixtureEvents
@@ -79,7 +79,7 @@ public:
     virtual ~FixtureManager();
 
     /**
-     * @brief setup is called by a test suit.
+     * @brief setup is called by a test suite.
      * The setup() function parses the fixture paramteres
      * and call the setup(int argc, char**argv) which can be
      * ovveriden by the user customized fixture manager.
@@ -102,7 +102,7 @@ public:
 
     /**
      * @brief check if the fixture is okay. This is called
-     * automatically from the corresponding test suit to ensure
+     * automatically from the corresponding test suite to ensure
      * the correctness of the fixture before running each test case.
      * @return true or false depending of correctness of the fixture
      */

--- a/src/rtf/include/rtf/PluginLoader.h
+++ b/src/rtf/include/rtf/PluginLoader.h
@@ -8,7 +8,7 @@
  */
 
 #if defined(WIN32)
-#	pragma once
+#    pragma once
 #endif
 
 #ifndef _RTF_PLUGINLOADER_H

--- a/src/rtf/include/rtf/ResultEvent.h
+++ b/src/rtf/include/rtf/ResultEvent.h
@@ -22,8 +22,8 @@ namespace RTF {
     class ResultEventError;
     class ResultEventStartTest;
     class ResultEventEndTest;
-    class ResultEventStartSuit;
-    class ResultEventEndSuit;
+    class ResultEventStartSuite;
+    class ResultEventEndSuite;
 }
 
 
@@ -124,21 +124,21 @@ public:
 };
 
 /**
- * @brief The ResultEventStartSuit class keeps a test suit starting event
+ * @brief The ResultEventStartSuite class keeps a test suite starting event
  */
-class RTF_API RTF::ResultEventStartSuit : public RTF::ResultEvent {
+class RTF_API RTF::ResultEventStartSuite : public RTF::ResultEvent {
 public:
-    ResultEventStartSuit(const RTF::Test* test, RTF::TestMessage msg)
+    ResultEventStartSuite(const RTF::Test* test, RTF::TestMessage msg)
         : ResultEvent(test, msg) {}
 };
 
 
 /**
- * @brief The ResultEventEndSuit class keeps a test suit ending event
+ * @brief The ResultEventEndSuite class keeps a test suite ending event
  */
-class RTF_API RTF::ResultEventEndSuit : public RTF::ResultEvent {
+class RTF_API RTF::ResultEventEndSuite : public RTF::ResultEvent {
 public:
-    ResultEventEndSuit(const RTF::Test* test, RTF::TestMessage msg)
+    ResultEventEndSuite(const RTF::Test* test, RTF::TestMessage msg)
         : ResultEvent(test, msg) {}
 };
 

--- a/src/rtf/include/rtf/TestCase.h
+++ b/src/rtf/include/rtf/TestCase.h
@@ -64,7 +64,7 @@ public:
      * @brief run is called by the TestCase class
      * if setup is successfull;
      */
-	virtual void run() = 0;
+    virtual void run() = 0;
 
     /**
      * @brief interrupt interrupts the current test run

--- a/src/rtf/include/rtf/TestListener.h
+++ b/src/rtf/include/rtf/TestListener.h
@@ -71,16 +71,16 @@ public:
     virtual void endTest(const RTF::Test* test) {}
 
     /**
-     * This is called when a TestSuit is started
+     * This is called when a TestSuite is started
      * @param test pointer to the corresponding test
      */
-    virtual void startTestSuit(const RTF::Test* test) {}
+    virtual void startTestSuite(const RTF::Test* test) {}
 
     /**
-     * This is called when a TestSuit is finished
+     * This is called when a TestSuite is finished
      * @param test pointer to the corresponding test
      */
-    virtual void endTestSuit(const RTF::Test* test) {}
+    virtual void endTestSuite(const RTF::Test* test) {}
 
     /**
      * This is called when the TestRunner is started

--- a/src/rtf/include/rtf/TestResult.h
+++ b/src/rtf/include/rtf/TestResult.h
@@ -104,16 +104,16 @@ public:
     void endTest(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is started
+     * This is called when a TestSuite is started
      * @param test pointer to the corresponding test
      */
-    void startTestSuit(const RTF::Test* test);
+    void startTestSuite(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is finished
+     * This is called when a TestSuite is finished
      * @param test pointer to the corresponding test
      */
-    void endTestSuit(const RTF::Test *test);
+    void endTestSuite(const RTF::Test *test);
 
     /**
      * This is called when the TestRunner is started

--- a/src/rtf/include/rtf/TestResultCollector.h
+++ b/src/rtf/include/rtf/TestResultCollector.h
@@ -26,7 +26,7 @@ namespace RTF {
  * \ingroup key_class
  *
  * \brief The TestResultCollector class can be used to store all the events
- * issued by the test cases, suits and runner during the test run.
+ * issued by the test cases, suites and runner during the test run.
  * The collected events later can be used by a proper result formatter
  * to be exported as HTML, XML or other desired formats.
  *
@@ -58,42 +58,42 @@ public:
 
     /**
      * @brief testCount gets the number of test cases. The test
-     * suits are not counted.
+     * suites are not counted.
      * @return the number of tests
      */
     unsigned int testCount();
 
     /**
      * @brief failedCount gets the number of failed test cases.
-     * The test suits are not counted.
+     * The test suites are not counted.
      * @return the number of failed tests.
      */
     unsigned int failedCount();
 
     /**
      * @brief passedCount gets the number of passed test cases.
-     * The test suits are not counted.
+     * The test suites are not counted.
      * @return the number of passed tests.
      */
     unsigned int passedCount();
 
     /**
-     * @brief suitCount gets the number of test suits.
-     * @return the number of test suits
+     * @brief suiteCount gets the number of test suites.
+     * @return the number of test suites
      */
-    unsigned int suitCount();
+    unsigned int suiteCount();
 
     /**
-     * @brief failedCount gets the number of failed test suits.
-     * @return the number of failed test suits.
+     * @brief failedCount gets the number of failed test suites.
+     * @return the number of failed test suites.
      */
-    unsigned int failedSuitCount();
+    unsigned int failedSuiteCount();
 
     /**
-     * @brief passedCount gets the number of passed test suits.
-     * @return the number of passed test suits.
+     * @brief passedCount gets the number of passed test suites.
+     * @return the number of passed test suites.
      */
-    unsigned int passedSuitCount();
+    unsigned int passedSuiteCount();
 
     /**
      * @brief getResults return any result event caught by
@@ -140,24 +140,24 @@ public:
     virtual void endTest(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is started
+     * This is called when a TestSuite is started
      * @param test pointer to the corresponding test
      */
-    virtual void startTestSuit(const RTF::Test* test);
+    virtual void startTestSuite(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is finished
+     * This is called when a TestSuite is finished
      * @param test pointer to the corresponding test
      */
-    virtual void endTestSuit(const RTF::Test* test);
+    virtual void endTestSuite(const RTF::Test* test);
 
 private:
     EventResultContainer events;
     unsigned int nTests;
     unsigned int nFailures;
     unsigned int nPasses;
-    unsigned int nTestSuits;
-    unsigned int nSuitFailures;
-    unsigned int nSuitPasses;
+    unsigned int nTestSuites;
+    unsigned int nSuiteFailures;
+    unsigned int nSuitePasses;
 };
 #endif // _RTF_TESTRESULTCOLLECTOR_H

--- a/src/rtf/include/rtf/TestRunner.h
+++ b/src/rtf/include/rtf/TestRunner.h
@@ -24,7 +24,7 @@ namespace RTF {
 /**
  * \ingroup key_class
  *
- * \brief The TestRunner class runs the tests added as TestCase or TestSuit.
+ * \brief The TestRunner class runs the tests added as TestCase or TestSuite.
  * It simply goes through a list of the tests and run them one after each other.
  *
  * Here's an example of using a TestRunner:

--- a/src/rtf/include/rtf/TestSuite.h
+++ b/src/rtf/include/rtf/TestSuite.h
@@ -8,8 +8,8 @@
  */
 
 
-#ifndef _RTF_TESTSUIT_H
-#define _RTF_TESTSUIT_H
+#ifndef _RTF_TESTSUITE_H
+#define _RTF_TESTSUITE_H
 
 #include <rtf/rtf_config.h>
 #include <rtf/Test.h>
@@ -19,29 +19,29 @@
 #include <set>
 
 namespace RTF {
-    class TestSuit;
+    class TestSuite;
 }
 
 
 /**
  * \ingroup key_class
  *
- * \brief The TestSuit holds a group of tests. When the \c run() method of a
- * TestSuit is called, it executes all its tests. A TestSuit can also has a FixtureManager.
+ * \brief The TestSuite holds a group of tests. When the \c run() method of a
+ * TestSuite is called, it executes all its tests. A TestSuite can also has a FixtureManager.
  * In this case, it calls the \c setup() method of FixtureManager to setup any fixture which
  * is required for the tests before executing the tests. After running all the tests, the \c tearDown()
  * method of the FixtureManager is called to tear down the fixture.
  *
  * The \c fixtureCollapsed method is used by a fixture manager to inform the test suit
  * that the corresponding fixture has been collapsed. In this case, an exception is thrown
- * by the TestSuit and the remaining tests will not be executed any more.  This method can be
+ * by the TestSuite and the remaining tests will not be executed any more.  This method can be
  * also overriden by a subclass if any specific action is required to be taken (such as retrying
  * to setup the fixture and runing the reamining tests) upon collapsing the fixture.
  *
- * Here's an example of using a TestSuit:
- * \include examples/simple_suit.cpp
+ * Here's an example of using a TestSuite:
+ * \include examples/simple_suite.cpp
  */
-class RTF_API RTF::TestSuit : public RTF::Test, public RTF::FixtureEvents {
+class RTF_API RTF::TestSuite : public RTF::Test, public RTF::FixtureEvents {
 
     typedef std::set<RTF::Test*> TestContainer;
     typedef std::set<RTF::Test*>::iterator TestIterator;
@@ -51,15 +51,15 @@ class RTF_API RTF::TestSuit : public RTF::Test, public RTF::FixtureEvents {
 public:
 
     /**
-     * TestSuit constructor
-     * @param  name The TestSuit name
+     * TestSuite constructor
+     * @param  name The TestSuite name
      */
-    TestSuit(std::string name);
+    TestSuite(std::string name);
 
     /**
-     *  TestSuit destructor
+     *  TestSuite destructor
      */
-    virtual ~TestSuit();
+    virtual ~TestSuite();
 
     /**
      * Adding a new test
@@ -80,7 +80,7 @@ public:
 
     /**
      * @brief addFixtureManager  add a fixture manager for
-     * the current test suit.
+     * the current test suite.
      * @param manager an instance of FixtureManager
      */
     void addFixtureManager(RTF::FixtureManager* manager);
@@ -95,7 +95,7 @@ public:
     virtual void fixtureCollapsed(RTF::TestMessage reason);
 
     /**
-     * the main caller of a TestSuit inherited from Test Class.
+     * the main caller of a TestSuite inherited from Test Class.
      * @param result an instance of a TestResult
      * to collect the result of the test.
      */
@@ -143,4 +143,4 @@ private:
     FixtureContainer fixtureManagers;
     TestContainer tests;
 };
-#endif // _RTF_TESTSUIT_H
+#endif // _RTF_TESTSUITE_H

--- a/src/rtf/include/rtf/WebProgressListener.h
+++ b/src/rtf/include/rtf/WebProgressListener.h
@@ -79,16 +79,16 @@ public:
     virtual void endTest(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is started
+     * This is called when a TestSuite is started
      * @param test pointer to the corresponding test
      */
-    virtual void startTestSuit(const RTF::Test* test);
+    virtual void startTestSuite(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is finished
+     * This is called when a TestSuite is finished
      * @param test pointer to the corresponding test
      */
-    virtual void endTestSuit(const RTF::Test* test);
+    virtual void endTestSuite(const RTF::Test* test);
 
     /**
      * This is called when the TestRunner is started

--- a/src/rtf/include/rtf/impl/WebProgressListener_impl.h
+++ b/src/rtf/include/rtf/impl/WebProgressListener_impl.h
@@ -81,16 +81,16 @@ public:
     virtual void endTest(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is started
+     * This is called when a TestSuite is started
      * @param test pointer to the corresponding test
      */
-    virtual void startTestSuit(const RTF::Test* test);
+    virtual void startTestSuite(const RTF::Test* test);
 
     /**
-     * This is called when a TestSuit is finished
+     * This is called when a TestSuite is finished
      * @param test pointer to the corresponding test
      */
-    virtual void endTestSuit(const RTF::Test* test);
+    virtual void endTestSuite(const RTF::Test* test);
 
     /**
      * This is called when the TestRunner is started
@@ -107,7 +107,7 @@ public:
     tthread::mutex critical;
     bool shouldStop;
     std::string result;
-    std::string suit_name;
+    std::string suite_name;
     unsigned int nTests;
     unsigned int nFailures;
     unsigned int nPasses;

--- a/src/rtf/include/rtf/rtf_config.h
+++ b/src/rtf/include/rtf/rtf_config.h
@@ -12,8 +12,8 @@
 #define _RTF_CONFIG_
 
 #if defined(WIN32)
-#	define RTF_FILTER_API
-#endif 
+#    define RTF_FILTER_API
+#endif
 
 #if defined _WIN32 || defined __CYGWIN__
 #  define RTF_HELPER_DLL_IMPORT __declspec(dllimport)
@@ -67,7 +67,7 @@
 
 //  always export symbols
 //#define RTF_API RTF_EXPORT
-#define RTF_API 
+#define RTF_API
 
 #if (__cplusplus >= 201103L)
 #  define RTF_NORETURN //TODO [[noreturn]] see issue #66

--- a/src/rtf/src/Asserter.cpp
+++ b/src/rtf/src/Asserter.cpp
@@ -54,9 +54,9 @@ void Asserter::report(RTF::TestMessage msg,
 }
 
 void Asserter::report(RTF::TestMessage msg,
-                      RTF::TestSuit* testsuit)
+                      RTF::TestSuite* testsuite)
 {
-    testsuit->getResult()->addReport(testsuit, msg);
+    testsuite->getResult()->addReport(testsuite, msg);
 }
 
 void Asserter::testFail(bool condition,

--- a/src/rtf/src/ConsoleListener.cpp
+++ b/src/rtf/src/ConsoleListener.cpp
@@ -87,16 +87,16 @@ void ConsoleListener::endTest(const RTF::Test* test) {
         cout<<" failed!"<<ENDC<<endl;
 }
 
-void ConsoleListener::startTestSuit(const RTF::Test* test) {
+void ConsoleListener::startTestSuite(const RTF::Test* test) {
     if(hideUncritical) return;
 
-    cout<<BLUE<<"Test suit "<<test->getName()<<" started..."<<ENDC<<endl;
+    cout<<BLUE<<"Test suite "<<test->getName()<<" started..."<<ENDC<<endl;
 }
 
-void ConsoleListener::endTestSuit(const RTF::Test* test) {
+void ConsoleListener::endTestSuite(const RTF::Test* test) {
     if(hideUncritical) return;
 
-    cout<<BLUE<<"Test suit "<<test->getName();
+    cout<<BLUE<<"Test suite "<<test->getName();
     if(test->succeeded())
         cout<<" passed!"<<ENDC<<endl;
     else

--- a/src/rtf/src/TestResult.cpp
+++ b/src/rtf/src/TestResult.cpp
@@ -60,12 +60,12 @@ void TestResult::endTest(const Test *test) {
     CALL_LISTENERS(endTest, test);
 }
 
-void TestResult::startTestSuit(const RTF::Test* test) {
-    CALL_LISTENERS(startTestSuit, test);
+void TestResult::startTestSuite(const RTF::Test* test) {
+    CALL_LISTENERS(startTestSuite, test);
 }
 
-void TestResult::endTestSuit(const RTF::Test* test) {
-    CALL_LISTENERS(endTestSuit, test);
+void TestResult::endTestSuite(const RTF::Test* test) {
+    CALL_LISTENERS(endTestSuite, test);
 }
 
 void TestResult::startTestRunner() {

--- a/src/rtf/src/TestResultCollector.cpp
+++ b/src/rtf/src/TestResultCollector.cpp
@@ -14,7 +14,7 @@ using namespace RTF;
 
 TestResultCollector::TestResultCollector() {
     nPasses = nFailures = nTests = 0;
-    nSuitPasses = nSuitFailures = nTestSuits = 0;
+    nSuitePasses = nSuiteFailures = nTestSuites = 0;
 }
 
 TestResultCollector::~TestResultCollector() {
@@ -42,16 +42,16 @@ unsigned int TestResultCollector::passedCount() {
     return nPasses;
 }
 
-unsigned int TestResultCollector::suitCount() {
-    return nTestSuits;
+unsigned int TestResultCollector::suiteCount() {
+    return nTestSuites;
 }
 
-unsigned int TestResultCollector::failedSuitCount() {
-    return nSuitFailures;
+unsigned int TestResultCollector::failedSuiteCount() {
+    return nSuiteFailures;
 }
 
-unsigned int TestResultCollector::passedSuitCount() {
-    return nSuitPasses;
+unsigned int TestResultCollector::passedSuiteCount() {
+    return nSuitePasses;
 }
 
 TestResultCollector::EventResultContainer& TestResultCollector::getResults() {
@@ -89,16 +89,16 @@ void TestResultCollector::endTest(const RTF::Test* test) {
 }
 
 
-void TestResultCollector::startTestSuit(const RTF::Test* test) {
-    nTestSuits++;
-    events.push_back(new ResultEventStartSuit(test,
+void TestResultCollector::startTestSuite(const RTF::Test* test) {
+    nTestSuites++;
+    events.push_back(new ResultEventStartSuite(test,
                                               TestMessage("started")));
 }
 
 
-void TestResultCollector::endTestSuit(const RTF::Test* test) {
+void TestResultCollector::endTestSuite(const RTF::Test* test) {
 
-    (test->succeeded()) ?  nSuitPasses++ : nSuitFailures++;
-    events.push_back(new ResultEventEndSuit(test,
+    (test->succeeded()) ?  nSuitePasses++ : nSuiteFailures++;
+    events.push_back(new ResultEventEndSuite(test,
                                             TestMessage("ended")));
 }

--- a/src/rtf/src/TestSuite.cpp
+++ b/src/rtf/src/TestSuite.cpp
@@ -8,49 +8,49 @@
  */
 
 #include <rtf/TestMessage.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/Exception.h>
 
 using namespace RTF;
 
-TestSuit::TestSuit(std::string name)
+TestSuite::TestSuite(std::string name)
     : RTF::Test(name),
     successful(true),
     fixtureOK(true),
-    fixtureMesssage(""),    
+    fixtureMesssage(""),
     result(NULL),
     current(NULL) { }
 
-TestSuit::~TestSuit() {
+TestSuite::~TestSuite() {
 
 }
 
-void TestSuit::addTest(RTF::Test* test) {
+void TestSuite::addTest(RTF::Test* test) {
     tests.insert(test);
 }
 
 
-void TestSuit::removeTest(RTF::Test* test) {
+void TestSuite::removeTest(RTF::Test* test) {
     tests.erase(test);
 }
 
-void TestSuit::reset() {
+void TestSuite::reset() {
     tests.clear();
     successful = fixtureOK =  true;
-    fixtureMesssage.clear();    
+    fixtureMesssage.clear();
     result = NULL;
 }
 
 
-bool TestSuit::succeeded() const {
+bool TestSuite::succeeded() const {
     return successful;
 }
 
-TestResult* TestSuit::getResult() {
+TestResult* TestSuite::getResult() {
     return result;
 }
 
-bool TestSuit::setup() {
+bool TestSuite::setup() {
     bool ret = true;
     FixtureIterator itr;
     for(itr=fixtureManagers.begin(); (itr!=fixtureManagers.end()) && ret; itr++)
@@ -59,25 +59,25 @@ bool TestSuit::setup() {
 }
 
 
-void TestSuit::tearDown() {
+void TestSuite::tearDown() {
     FixtureIterator itr;
     for(itr=fixtureManagers.begin(); itr!=fixtureManagers.end(); itr++)
         (*itr)->tearDown();
 }
 
 
-void TestSuit::run(TestResult &rsl) {
+void TestSuite::run(TestResult &rsl) {
     this->result = &rsl;
     successful = fixtureOK = true;
     interrupted = false;
     fixtureMesssage.clear();
     try {
-        result->startTestSuit(this);
-        // calling test suit setup
+        result->startTestSuite(this);
+        // calling test suite setup
         if (!setup()) {
             result->addError(this, RTF::TestMessage("setup() failed!"));
             successful = false;
-            result->endTestSuit(this);
+            result->endTestSuite(this);
             return;
         }
 
@@ -159,27 +159,27 @@ void TestSuit::run(TestResult &rsl) {
         result->addError(this, RTF::TestMessage(e.what()));
     }
 
-    result->endTestSuit(this);
+    result->endTestSuite(this);
     current = NULL;
 }
 
 
-void TestSuit::addFixtureManager(RTF::FixtureManager* manager) {
+void TestSuite::addFixtureManager(RTF::FixtureManager* manager) {
     manager->setDispatcher(this);
     fixtureManagers.insert(manager);
 }
 
-void TestSuit::fixtureCollapsed(RTF::TestMessage reason) {
+void TestSuite::fixtureCollapsed(RTF::TestMessage reason) {
 
     // we do not want to throw any exception here.
     // The reason is that if fixtureCollapsed is called
     // within other threads, the exception cannot be caught
-    // by the TestSuit.
+    // by the TestSuite.
     fixtureOK = false;
     fixtureMesssage = reason;
 }
 
-void TestSuit::interrupt() {
+void TestSuite::interrupt() {
     if(current)
         current->interrupt();
     interrupted = true;

--- a/src/rtf/src/TextOutputter.cpp
+++ b/src/rtf/src/TextOutputter.cpp
@@ -54,11 +54,11 @@ bool TextOutputter::write(std::string filename, bool summary,
        ResultEvent* e = *itr;
 
        // start suit
-       if(dynamic_cast<ResultEventStartSuit*>(e))
-           outputter<<"Test suit "<<e->getTest()->getName()<<" started..."<<endl;
+       if(dynamic_cast<ResultEventStartSuite*>(e))
+           outputter<<"Test suite "<<e->getTest()->getName()<<" started..."<<endl;
        // end suit
-       else if(dynamic_cast<ResultEventEndSuit*>(e)) {
-           outputter<<"Test suit "<<e->getTest()->getName();
+       else if(dynamic_cast<ResultEventEndSuite*>(e)) {
+           outputter<<"Test suite "<<e->getTest()->getName();
            if(e->getTest()->succeeded())
                outputter<<" passed!"<<endl;
            else
@@ -112,10 +112,10 @@ bool TextOutputter::write(std::string filename, bool summary,
     if(summary) {
         // write some simple statistics
         outputter<<endl<<"---------- summary -----------"<<endl;
-        if(collector.suitCount()) {
-            outputter<<"Total number of test suites  : "<<collector.suitCount()<<endl;
-            outputter<<"Number of passed test suites : "<<collector.passedSuitCount()<<endl;
-            outputter<<"Number of failed test suites : "<<collector.failedSuitCount()<<endl;
+        if(collector.suiteCount()) {
+            outputter<<"Total number of test suites  : "<<collector.suiteCount()<<endl;
+            outputter<<"Number of passed test suites : "<<collector.passedSuiteCount()<<endl;
+            outputter<<"Number of failed test suites : "<<collector.failedSuiteCount()<<endl;
         }
         outputter<<"Total number of test cases   : "<<collector.testCount()<<endl;
         outputter<<"Number of passed test cases  : "<<collector.passedCount()<<endl;

--- a/src/rtf/src/WebProgressListener.cpp
+++ b/src/rtf/src/WebProgressListener.cpp
@@ -82,7 +82,7 @@ static std::string html_page =
 "    xmlStatus.onreadystatechange=function() {\n"
 "        if (xmlStatus.readyState==4 && xmlStatus.status==200) {\n"
 "           var status = JSON.parse(xmlStatus.responseText);\n"
-"           document.getElementById(\"suit_name\").innerHTML=status.name;\n"
+"           document.getElementById(\"suite_name\").innerHTML=status.name;\n"
 "           var c = document.getElementById(\"progress\");\n"
 "           var ctx = c.getContext(\"2d\");\n"
 "           ctx.clearRect(0, 0, c.width, c.height);\n"
@@ -131,7 +131,7 @@ static std::string html_page =
 "<body bgcolor=\"#efefef\">\n"
 "<div class=\"my_window\" style=\"height:52px\">\n"
 "<div style=\"position:relative; padding:5px; float:left;\"> <img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAApCAYAAAD+tu2AAAAACXBIWXMAAAKMAAACjAGAOtAHAAANL0lEQVR42u2ce5CV5X3HP7/3nLM3kMtChBUEjIAIBOI5AUQwGrUYIYk0E5Lm1oydTGynjq1xbJtWTRljjJlo0k7bjJ2mlxlrQp3WWnUajRhvCFHfA+KFKqBcl/tN9uyes+d9n1//OL+FXfac55xld8G1fWae2XfP+7zP5ff93d/neQUrHU98h8Zl99Dxn384PBg7Y6k69y1ccQ6qzaAJai5C34vkCYKDBMlfIvxzw+Kb15xGJ6TTabLZLACZTGYesBT4DDAFGOt5tAjsBjap6i9EZHUYhrszmQxhGPZomMlk/hz4DhAxcOVQGIZTTxmHMAzJZDJjVPUaEfkSMBeYCNTV2K/rgUbHU9+7ShpHrdYj24l3vqLamet2X3s/rgxoCUa2aGLK5UKy7pDm9s9sXPr9/bU+240gdaq6XkRmnu48VBURuT8Mw1vLjHMXcPvArpxDYRiOLcOwvy8iP+1Hvy7oePRPS+A+86N7cfHq4oaHid5ZrZo/LjjlZKVnjU9e6wDV+HCrdGZXafQ/vxojTR/Z3v7Y7VfUupIwDEmn0/OBQwbuabOfiKiqfjuTyWzKZDJNnIWSyWT+u5/gloSm8fp7aX/izmV6/MCfRBseUTrawIkQA7FWrt3Al9OpcZnqQByiR/dSfO3RemkY8Wj7wzc31kiQ6SLyG2B4P2xFN4wFYAawPpPJyBkCtevvKuDTA6IV21fdNEKSjY/Hb/9aVQPRWBnI6mqurmfNHZNo09MjpWnMUzUS5rGBNxoATAd+fiYANhPzSeCLA9VnUkZOWBa9/SyuWDw9plcHhTYSUy8nNXMJwehJyLDmyrSOi7gju4h3hHS+/HNIJJEgWd6AHNun2n58ce7Rv5g27Pq7N3ts5u+IyPRBorsCX0qn0yuz2eymbjZ6wAdKp9P1wC8Hsv+kO7bvRndsH4JIyajWiqtDmkZRN+/L1C36PSRZd6qTUg4JECExYQ6p2UtpWHoHnb95kMJzD6CFtjLtRYpbXiI1Z9klwGaPPv3xIAqW2BifB+6268EZSGQO0DiQ/Sc13zZTY0X7qN2SF1zKsN994CRwPSdaaQW9fqpb8DWSs66j7a+WocV8bx2Sz+GOtl4O/FsF9XweML6KRxwD7VWWNAwIPPe/aQDngKOqWizTpllEEp65HChn7FX1sP17ZQ2kbzcXtyY5TGoh3yyuD/oq6qRx+Urq5q3wAtcnR2D4GM655UmO//BqcGXCy0JhqodoI30cb/c+4dMAgKjqUhFZ5WkzxezkD4AfVGC2LcCFlRgtm82eW4UUF1YJ3x4WkRv6JsGdhYQ6rRLbln7UYp7GT99K3bwVA2uHVJGmkaQ+8QUKax6EoKcgSWfBl2hpqkKU3dlsdkMN9u+F/i+jMk1qpNX4Kvd/pqq5rmROTcJDFFvo4zy1FBqlZl5L/adu7MuEazU+ANRf+S3Id/QKn4ji/sS0UY3tBsMDH/DSF3ABksRxKZ6tkp1SdTT+9h0nHKXBKMHwZoLmyejxAz2monFcTQX/XykPZTKZQl+USlKjGBdXSUO6mPrFXyUYce6gryAYP43i0f09Xdg4dqejFj9sRUSa+5qqTBK7khr0sUHsaPzsbd428f73yD/+E7SQKx9Pu4jU3GuoX/xV/1gdOcSdgmfsBp14qiofRkZJEsdoFfoFY6cgqXqvtLz/vet6qu4yPBPteLMqwO7Arl7z0SjSM6CiJ3wYpT6psTlZPoBHjvcSM9r6KprvQOqbvHZcho2p6oXGrVuQxnNOlWDtr4pOp9PrPEwSWCjlK61DE+AoBucq5uiIYxITZ3s7KW5aC5JCqzHKqBbv/ejttSCJ3v30w4vuBuKCfqrwvx2iALuKKloVKHSSnLHQD/DW9agk/JnOOCI5ZW5VRlFJ9ernDKloD7YqwD8OWRtcSUUL4DrzpC5e5LebB1uR2KObAS0USF7kZ5To3dcQTdh8tCYJHmQvWrWUhl2QzWb3DkF8gyTFCPV4qYnx0yoSsIu48cE9aFT0hlrSNIrURfP9/ezbiStjLiSKzxaBRETmh2H4SrntO2e6qOofiMiLfZPgyHlVa2rGZd4kgzt6AHdoL03Lb4JTQXaGcl0DTctv9vaj+Xbi3e8iqTLbjeIzECdVLi9nMpnpYRhu/gBI5LYwDN8YUC86OdOvVgvrHifZMo1hX7mjXzM/dt83QYKyjpoWo7MpNYjIG+l0ur6vacIPhI7WOMY5rVgT4z+KamUGKLz0OKlZi/o1ic4311J8Yy1oUPLoXc9cuHrCpIHE0uPE1YnIx7q21Aw5L9qXyUo0j6/sxKhSfCdLw7XfOO0JRDvf4ejty5H6pvK+gALF/tvgMAzFEyOvAS6r4qwtDMPw9SEnwcSuwi5HxTlHMHpc5cjnUCs4SIyb7JXysrwRdXL8727jyG1LIdXk33Hp8aL740Gn0+muy+9W60dVFzAESxAXo7KvCLUYUzdrsdc2uYN7wSmBT8o9DnxyxnxwlN9heWKnpeI8XnRfGat76bKpIvLcYCdKzp4ER67sbkiKEfULP+P1fKMdb4MTEs3j+h5/BAGNV60gNfeKyjsru2oxGlQbHIZhEThcpdmsIQmwi7WSWqR+0TK/Bx0+R/Li+f2SruTEaVAs2n5pylaNzsj74GerNbD9X0PMyYq19+s5QEaMJWg6x5spKmafJ3nRJeT+/adl89n1i5aSPO8C7wQSE6dCMSqlOitlyjxO4ABmsp4FPl+FWRcAjwwpgJ1zZQmYHNPilRDXkSPau5u47TiF8Pny4c/GtYy+60H/DJxD7aRDxSYJ7Q+CQQ2SiapurMYoZod9APeX02QQJLikBntGJkpijP/NT2f2BSSRwrsjM0hV96ZzbaUzcN4XFeoj+nvA1zxP52qwwaTT6Q1V+gHYUYUBbgHOqaSsasDjPipsD7byWt8lOHa9skcaFambfWkVgJ+HhP8VYaUTCz2ks+390gE2Tz9x4MQDzmHgX6uFQ9WyUNls9li1fmpglP/qT8gWhhVUYX8kOI6JiXue/9V8nrpLLvc+WNzyVinz5NsOElRnWpdrQx2IJ90ci/YrVzkUUoyDNcdkrLoX1Z7bVZySmj7H+2C8v9WSex6zkaguwdp+HALx7tSMYSv/X07PASmqbEBAxYgsQt3s6qGP27+7hK2nSi0A545XZhJVYqBD5WVPF58Cat1tOA7oSpxPAS49Tbq1AB//AOI5qdv6ShLc4fiXPMGyBnUn4o3k1FnE+3aVf8crQrTzXbSQR+rq/eq3kCfetxuNOiu3OXKgrKeuJdj1CClxLq70IvZjwDPA9cBTlM4XTbJ7e4C93cBsBm4CvmxEuNN+T1M6IjrMkh3bzCGayslTEw7oOh3xY+CPgSeBL1A6btJqbc63Nu8Bx2zMyZQ+EfEeMM2WthVoA86l9EkGtfv1lDb/ZYEx9uwGc9wuNCfrPOAjQIHScZxO+20E8E/AaErnmqcB9fLalZOaCmhugkQqJyCWKpvbtXS6sJb4U6pEKRX3C0Ee4aAmHpv33M7PVXj6VuBHdv3FUzzQ3Ua8R4DPWbi0rpvUZoHtBu6sk9aAucD9wJJTxrkfmAm8CbxqQP8MaABuAe7l5LczCsBFxixdJW9tAV4EvkFP07MdeAK4wRjrPuDbpt7+DLgHWAl8t9szD1LaSvSMMcgU4IeUPjGRB1YGc5/d0a6xXr03CiSQrtSTVvneQh+SC9W+21BGcimxvO6N5HAQxys8vX/SuLgF+CPj9snArzh5mjBtBJhsnP6QqeqLjXizgOuAhSa5XzdwW0wKANbb365DcBdY0qPBri8ziR0P/KVJ4ipgo427xgCcDDwNjAJCY75RtoZ3gGXAwzbGtd2ya79lAN5gTDUZeN0AfRL4G2C5rWcF8IZpo78O1i5qYcELu57Jxe6ubQWRojuB8FkxIgKac8q2TtpRtyTzYqvvqMb5tpAGA68VaLTfHzIpirrFsJOATUDK2m23e+s4GYlv6abiNxuxfm2/XWHtxpoa3GVSerX1kTKmOG7AbbRxR1tfO+z3vP3dAMy2+d9jwK03zTMLeMWY5irgH2z+r9vcJwAHbczHzMQAHDCVPgw4Fixcs6ckCi/tubPg3OLNecfOgpOiO/OHsXKx6uaOWHbkdZc4d/7CNXuqbYI6YJJ0h4G71ACcYXZ5E/BR4CfdQLsL6Np932SSftSYoUvVAzwAfMXsPN2kqusTT0uAX9j1y8BngRfMBPyH9bfa7l9oarlL+p82ZbXSnploczliqn+nmYvbbF27ge8Dh2wtm4wp7rY+t3Wb5zVmtpqAsSf07JrLWlj00h7WLBjbkIu5TuHrSWFeAOMQUr106AAWhTYHe2LlCYFVS149uK4vOQKTpIN2nTRVdQQYaRLYlc0abpJxwCSoYCt6y6R+gnnHd5qDVA/8PXCjPX+pEXyHmYcuVRgAGeB9c47eNXW+3sZeZGMcsT622nPpbhmut2w+HzcH7E1gvjloGw3wETb/TvMhRpsP8YoxSYtpkjGmSbL/C1wSAN16Ymy3AAAAAElFTkSuQmCC\"/> </div>\n"
-"<div style=\"position:relative; padding:5px; float:center;\"> <h4 id=\"suit_name\" style=\"text-align: center; margin:0;\" class=\"font_h4\">Robot Testing Framework</h4></div>\n"
+"<div style=\"position:relative; padding:5px; float:center;\"> <h4 id=\"suite_name\" style=\"text-align: center; margin:0;\" class=\"font_h4\">Robot Testing Framework</h4></div>\n"
 "</div>\n"
 "<div class=\"my_window\" style=\"top:75px; height:90%; padding:5px\"><div id=\"result\" style=\"top:0px; height:96%; overflow-y:scroll; background:#ffffff;\"></div>\n"
 "<table style=\"width:100%\"><tr><td width=\"90%\"><canvas id=\"progress\" width=\"1000px\" height=\"20px\" style=\"width:1000px; height:20px\" ></canvas></td><td align=\"right\"><input align=\"right\" type=\"checkbox\" id=\"autoscroll\" checked/> auto scroll</div></td></tr></table>\n"
@@ -162,10 +162,10 @@ WebProgressListenerImpl::WebProgressListenerImpl(unsigned int port,
     }
 }
 
-WebProgressListenerImpl::~WebProgressListenerImpl() {    
+WebProgressListenerImpl::~WebProgressListenerImpl() {
     shouldStop = true;
     // stop the pooling thread
-    if(updater) {        
+    if(updater) {
         updater->join();
         delete updater;
         updater = NULL;
@@ -182,8 +182,8 @@ WebProgressListenerImpl::~WebProgressListenerImpl() {
 void WebProgressListenerImpl::update(void *param) {
     WebProgressListenerImpl* web = (WebProgressListenerImpl*) param;
     while(!web->shouldStop) {
-        mg_poll_server(web->server, 1000);		
-	}
+        mg_poll_server(web->server, 1000);
+    }
 }
 
 int WebProgressListenerImpl::handler(struct mg_connection *conn,
@@ -204,10 +204,10 @@ int WebProgressListenerImpl::handler(struct mg_connection *conn,
             web->critical.lock();
 #if defined(WIN32)
             _snprintf(json, 512, "{\"name\":%s,\"ntest\":%d,\"nfail\":%d,\"npass\":%d}",
-                     web->suit_name.c_str(), web->nTests, web->nFailures, web->nPasses);
+                     web->suite_name.c_str(), web->nTests, web->nFailures, web->nPasses);
 #else
             snprintf(json, 512, "{\"name\":\"%s\",\"ntest\":%d,\"nfail\":%d,\"npass\":%d}",
-                     web->suit_name.c_str(), web->nTests, web->nFailures, web->nPasses);
+                     web->suite_name.c_str(), web->nTests, web->nFailures, web->nPasses);
 #endif
             web->critical.unlock();
             mg_send_header(conn, "Content-Type", "text/turtle");
@@ -283,11 +283,11 @@ void WebProgressListenerImpl::startTest(const RTF::Test* test) {
     string text = Asserter::format("<br> %s Test case %s started... %s",
                                   BLUE,
                                   encode(test->getName()).c_str(),
-                                  ENDC);    
+                                  ENDC);
     critical.lock();
-    // if there is no test suit, use the test case's name
-    if(suit_name.size()==0)
-        suit_name = test->getName();
+    // if there is no test suite, use the test case's name
+    if(suite_name.size()==0)
+        suite_name = test->getName();
     nTests++;
     result += text;
     critical.unlock();
@@ -298,30 +298,30 @@ void WebProgressListenerImpl::endTest(const RTF::Test* test) {
                                   BLUE,
                                   encode(test->getName()).c_str(),
                                   (test->succeeded()) ? "passed!" : "failed!",
-                                  ENDC);    
+                                  ENDC);
     critical.lock();
     (test->succeeded()) ?  nPasses++ : nFailures++;
     result += text;
     critical.unlock();
 }
 
-void WebProgressListenerImpl::startTestSuit(const RTF::Test* test) {
+void WebProgressListenerImpl::startTestSuite(const RTF::Test* test) {
     string text = Asserter::format("<br> %s Test suite %s started... %s",
                                   BLUE,
                                   encode(test->getName()).c_str(),
-                                  ENDC);    
+                                  ENDC);
     critical.lock();
     result += text;
-    suit_name = test->getName();
+    suite_name = test->getName();
     critical.unlock();
 }
 
-void WebProgressListenerImpl::endTestSuit(const RTF::Test* test) {
+void WebProgressListenerImpl::endTestSuite(const RTF::Test* test) {
     string text = Asserter::format("<br> %s Test suite %s %s %s",
                                   BLUE,
                                   encode(test->getName()).c_str(),
                                   (test->succeeded()) ? "passed!" : "failed!",
-                                  ENDC);    
+                                  ENDC);
     critical.lock();
     result += text;
     critical.unlock();
@@ -329,7 +329,7 @@ void WebProgressListenerImpl::endTestSuit(const RTF::Test* test) {
 
 void WebProgressListenerImpl::startTestRunner() {
     string text = Asserter::format("<br> %s Staring test runner. %s",
-                                  BLUE, ENDC);    
+                                  BLUE, ENDC);
     critical.lock();
     result += text;
     critical.unlock();
@@ -337,7 +337,7 @@ void WebProgressListenerImpl::startTestRunner() {
 
 void WebProgressListenerImpl::endTestRunner() {
     string text = Asserter::format("<br> %s Ending test runner. %s",
-                                  BLUE, ENDC);    
+                                  BLUE, ENDC);
     critical.lock();
     result += text;
     critical.unlock();
@@ -379,12 +379,12 @@ void WebProgressListener::endTest(const RTF::Test* test) {
     ((WebProgressListener*)implement)->endTest(test);
 }
 
-void WebProgressListener::startTestSuit(const RTF::Test* test) {
-    ((WebProgressListener*)implement)->startTestSuit(test);
+void WebProgressListener::startTestSuite(const RTF::Test* test) {
+    ((WebProgressListener*)implement)->startTestSuite(test);
 }
 
-void WebProgressListener::endTestSuit(const RTF::Test* test) {
-    ((WebProgressListener*)implement)->endTestSuit(test);
+void WebProgressListener::endTestSuite(const RTF::Test* test) {
+    ((WebProgressListener*)implement)->endTestSuite(test);
 }
 
 void WebProgressListener::startTestRunner() {

--- a/src/testrunner/include/SuiteRunner.h
+++ b/src/testrunner/include/SuiteRunner.h
@@ -8,47 +8,47 @@
  */
 
 
-#ifndef _RTF_SuitRunner_H
-#define _RTF_SuitRunner_H
+#ifndef _RTF_SuiteRunner_H
+#define _RTF_SuiteRunner_H
 
 #include <string>
 #include <vector>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <PluginRunner.h>
 #include <rtf/dll/DllFixturePluginLoader.h>
 
 /**
- * class SuitRunner
+ * class SuiteRunner
  */
-class SuitRunner : public PluginRunner {
+class SuiteRunner : public PluginRunner {
 
 public:
 
     /**
-     * SuitRunner constructor
+     * SuiteRunner constructor
      */
-    SuitRunner(bool verbose=false);
+    SuiteRunner(bool verbose=false);
 
     /**
-     *  SuitRunner destructor
+     *  SuiteRunner destructor
      */
-    virtual ~SuitRunner();
+    virtual ~SuiteRunner();
 
     /**
-     * @brief loadSuit loads a single test suit (xml file)
+     * @brief loadSuite loads a single test suite (xml file)
      * @param filename the xml file name
      * @return true or false upon success or failure
      */
-    bool loadSuit(std::string filename);
+    bool loadSuite(std::string filename);
 
     /**
-     * @brief loadMultipleSuits loads all test suits from the
+     * @brief loadMultipleSuites loads all test suites from the
      * given path
-     * @param path the path to the test suits xml files
+     * @param path the path to the test suites xml files
      * @param recursive loads from subfolders if true
      * @return true or false upon success or failure
      */
-    bool loadMultipleSuits(std::string path, bool recursive=false);
+    bool loadMultipleSuites(std::string path, bool recursive=false);
 
     /**
      * Clear the test list
@@ -56,12 +56,12 @@ public:
     void reset();
 
 private:
-    bool loadSuitsFromPath(std::string path);
+    bool loadSuitesFromPath(std::string path);
 
 private:
     bool verbose;
-    std::vector<RTF::TestSuit*> suits;
+    std::vector<RTF::TestSuite*> suites;
     std::vector<RTF::plugin::DllFixturePluginLoader*> fixtureLoaders;
 };
 
-#endif // _RTF_SuitRunner_H
+#endif // _RTF_SuiteRunner_H

--- a/src/testrunner/src/JUnitOutputter.cpp
+++ b/src/testrunner/src/JUnitOutputter.cpp
@@ -37,23 +37,23 @@ bool JUnitOutputter::write(std::string filename,
         return false;
     }
 
-    TiXmlDocument doc;   
+    TiXmlDocument doc;
     TiXmlElement* root = new TiXmlElement("testsuites");
-    root->SetAttribute("suites", collector.suitCount());
+    root->SetAttribute("suites", collector.suiteCount());
     root->SetAttribute("tests", collector.testCount());
     root->SetAttribute("failures", collector.failedCount());
     doc.LinkEndChild(root);
 
-    TiXmlElement* testsuit = NULL;
+    TiXmlElement* testsuite = NULL;
     TiXmlElement* testcase = NULL;
     string classname;
 
     // If there is not any test suite, add one!
-    if(collector.suitCount() == 0) {
+    if(collector.suiteCount() == 0) {
         classname = "default";
-        testsuit = new TiXmlElement("testsuite");
-        testsuit->SetAttribute("name", classname.c_str());
-        root->LinkEndChild(testsuit);
+        testsuite = new TiXmlElement("testsuite");
+        testsuite->SetAttribute("name", classname.c_str());
+        root->LinkEndChild(testsuite);
     }
 
     TestResultCollector::EventResultIterator itr;
@@ -64,22 +64,22 @@ bool JUnitOutputter::write(std::string filename,
        ResultEvent* e = *itr;
 
        // start suit
-       if(dynamic_cast<ResultEventStartSuit*>(e)) {
+       if(dynamic_cast<ResultEventStartSuite*>(e)) {
            classname = e->getTest()->getName();
-           testsuit = new TiXmlElement("testsuite");
-           testsuit->SetAttribute("name", classname.c_str());
-           root->LinkEndChild(testsuit);
+           testsuite = new TiXmlElement("testsuite");
+           testsuite->SetAttribute("name", classname.c_str());
+           root->LinkEndChild(testsuite);
        }
        // end suit
-       //else if(dynamic_cast<ResultEventEndSuit*>(e)) { }
+       //else if(dynamic_cast<ResultEventEndSuite*>(e)) { }
 
-       // start test case       
+       // start test case
        else if(dynamic_cast<ResultEventStartTest*>(e)) {
-           if(testsuit == NULL) continue;
+           if(testsuite == NULL) continue;
            testcase = new TiXmlElement("testcase");
            testcase->SetAttribute("name", e->getTest()->getName());
            testcase->SetAttribute("classname", classname+"."+e->getTest()->getName());
-           testsuit->LinkEndChild(testcase);
+           testsuite->LinkEndChild(testcase);
            errorMessages.clear();
            failureMessages.clear();
            reportsMessages.clear();

--- a/src/testrunner/src/SuiteRunner.cpp
+++ b/src/testrunner/src/SuiteRunner.cpp
@@ -81,7 +81,17 @@ bool SuiteRunner::loadSuite(std::string filename) {
         return false;
     }
 
-    if(!PluginFactory::compare(root->Value(), "suite")) {
+    bool rootTagIsSuite = PluginFactory::compare(root->Value(), "suite");
+    bool rootTagIsSuit = PluginFactory::compare(root->Value(), "suit");
+
+    if(rootTagIsSuit)
+    {
+        logger.addWarning(Asserter::format("Root tag of the xml file is the \" suit \" tag, that is deprecated since RTF 1.3, and will be removed in RTF 1.5 .",
+                                           "Please use the \" suite \" tag instead."));
+    }
+
+
+    if(!(rootTagIsSuit || rootTagIsSuite)) {
         if(verbose)
             cout<<filename<<" is not a test suite file!"<<endl;
         return false;

--- a/src/testrunner/src/SuiteRunner.cpp
+++ b/src/testrunner/src/SuiteRunner.cpp
@@ -8,7 +8,7 @@
  */
 
 #include <rtf/Asserter.h> // used to format the string message
-#include <SuitRunner.h>
+#include <SuiteRunner.h>
 #include <ErrorLogger.h>
 #include <PlatformDir.h>
 #include <tinyxml.h>
@@ -19,23 +19,23 @@ using namespace std;
 using namespace RTF;
 using namespace RTF::plugin;
 
-SuitRunner::SuitRunner(bool verbose)
+SuiteRunner::SuiteRunner(bool verbose)
     : PluginRunner(verbose),
       verbose(verbose) {
 }
 
-SuitRunner::~SuitRunner() {
+SuiteRunner::~SuiteRunner() {
     reset();
 }
 
-void SuitRunner::reset() {
+void SuiteRunner::reset() {
     // first reset the PluginRunner
     PluginRunner::reset();
 
-    // delete all the suits which was created
-    for(unsigned int i=0; i<suits.size(); i++)
-        delete suits[i];
-    suits.clear();
+    // delete all the suites which was created
+    for(unsigned int i=0; i<suites.size(); i++)
+        delete suites[i];
+    suites.clear();
 
     // delete all the fixture plugin loader which was created
     for(unsigned int i=0; i<fixtureLoaders.size(); i++)
@@ -43,7 +43,7 @@ void SuitRunner::reset() {
     fixtureLoaders.clear();
 }
 
-bool SuitRunner::loadSuit(std::string filename) {
+bool SuiteRunner::loadSuite(std::string filename) {
     if(verbose)
         cout<<"Loading "<<filename<<endl;
 
@@ -59,7 +59,7 @@ bool SuitRunner::loadSuit(std::string filename) {
         bOK = doc.LoadFile();
     }
     catch(...) {
-        string error = Asserter::format("Caught an exception while trying to open suit '%s'. (Is it a XML file?)",
+        string error = Asserter::format("Caught an exception while trying to open suite '%s'. (Is it a XML file?)",
                                         filename.c_str());
         logger.addError(error);
         return false;
@@ -81,15 +81,15 @@ bool SuitRunner::loadSuit(std::string filename) {
         return false;
     }
 
-    if(!PluginFactory::compare(root->Value(), "suit")) {
+    if(!PluginFactory::compare(root->Value(), "suite")) {
         if(verbose)
-            cout<<filename<<" is not a test suit file!"<<endl;
+            cout<<filename<<" is not a test suite file!"<<endl;
         return false;
     }
 
     std::string environment;
     std::string name = (root->Attribute("name")) ? root->Attribute("name") : "unknown";
-    TestSuit* suit = new TestSuit(name);
+    TestSuite* suite = new TestSuite(name);
 
     // retrieving test cases
     for(TiXmlElement* test = root->FirstChildElement(); test;
@@ -97,7 +97,7 @@ bool SuitRunner::loadSuit(std::string filename) {
     {
         if(PluginFactory::compare(test->Value(), "description")) {
             if(test->GetText() != NULL)
-                suit->setDescription(test->GetText());
+                suite->setDescription(test->GetText());
         }
         else if(PluginFactory::compare(test->Value(), "environment")) {
             if(test->GetText() != NULL)
@@ -120,7 +120,7 @@ bool SuitRunner::loadSuit(std::string filename) {
                     if(test->Attribute("param"))
                         fixture->setParam(test->Attribute("param"));
                     // set the fixture manager for the current suit
-                    suit->addFixtureManager(fixture);
+                    suite->addFixtureManager(fixture);
                     // keep track of the created plugin loaders
                     fixtureLoaders.push_back(loader);
                 }
@@ -128,7 +128,7 @@ bool SuitRunner::loadSuit(std::string filename) {
                     logger.addError(loader->getLastError());
                     delete loader;
                     // stop going on if the fixture manager cannot be loaded
-                    delete suit;
+                    delete suite;
                     return false;
                 }
         }
@@ -178,7 +178,7 @@ bool SuitRunner::loadSuit(std::string filename) {
                     }
                 }
                 // add the test to the suit
-                suit->addTest(testcase);
+                suite->addTest(testcase);
                 // keep track of the created plugin loaders
                 dllLoaders.push_back(loader);
             }
@@ -189,17 +189,17 @@ bool SuitRunner::loadSuit(std::string filename) {
         }
     }
 
-    // add the test suit to the TestRunner
-    addTest(suit);
-    // keep tracks of the created suits
-    suits.push_back(suit);
+    // add the test suite to the TestRunner
+    addTest(suite);
+    // keep tracks of the created suites
+    suites.push_back(suite);
     return true;
 }
 
-bool SuitRunner::loadMultipleSuits(std::string path,
+bool SuiteRunner::loadMultipleSuites(std::string path,
                                          bool recursive) {
     if(!recursive)
-        return loadSuitsFromPath(path);
+        return loadSuitesFromPath(path);
 
     // load from subfolders
     if((path.rfind(PATH_SEPERATOR)==string::npos) ||
@@ -213,7 +213,7 @@ bool SuitRunner::loadMultipleSuits(std::string path,
         return false;
     }
 
-    loadSuitsFromPath(path);
+    loadSuitesFromPath(path);
 
     while((entry = readdir(dir))) {
         if((entry->d_type == DT_DIR) &&
@@ -221,16 +221,16 @@ bool SuitRunner::loadMultipleSuits(std::string path,
                 (string(entry->d_name) != string("..")))
         {
             string name = path + string(entry->d_name);
-            loadMultipleSuits(name, recursive);
+            loadMultipleSuites(name, recursive);
         }
     }
     closedir(dir);
     return true;
 }
 
-bool SuitRunner::loadSuitsFromPath(std::string path) {
+bool SuiteRunner::loadSuitesFromPath(std::string path) {
     if(verbose)
-        cout<<"Loading suits from "<<path<<endl;
+        cout<<"Loading suites from "<<path<<endl;
 
     if((path.rfind(PATH_SEPERATOR)==string::npos) ||
         (path.rfind(PATH_SEPERATOR)!=path.size()-1))
@@ -249,7 +249,7 @@ bool SuitRunner::loadSuitsFromPath(std::string path) {
             // check for xml file
             string ext = name.substr(name.size()-4,4);
             if(PluginFactory::compare(ext.c_str(), ".xml"))
-                loadSuit(path+name);
+                loadSuite(path+name);
         }
     }
     closedir(dir);

--- a/src/testrunner/src/main.cpp
+++ b/src/testrunner/src/main.cpp
@@ -17,7 +17,7 @@
 #include <JUnitOutputter.h>
 
 #include <cmdline.h>
-#include <SuitRunner.h>
+#include <SuiteRunner.h>
 #include <ErrorLogger.h>
 #include <Version.h>
 
@@ -57,12 +57,12 @@ void addOptions(cmdline::parser &cmd) {
                     "Runs multiple tests from the given folder which contains plugins.",
                     false);
 
-    cmd.add<string>("suit", 's',
-                    "Runs a single test suit from the given XMl file.",
+    cmd.add<string>("suite", 's',
+                    "Runs a single test suite from the given XMl file.",
                     false);
 
-    cmd.add<string>("suits", '\0',
-                    "Runs multiple test suits from the given folder which contains XML files.",
+    cmd.add<string>("suites", '\0',
+                    "Runs multiple test suites from the given folder which contains XML files.",
                     false);
 
     cmd.add("no-output", '\0',
@@ -93,7 +93,7 @@ void addOptions(cmdline::parser &cmd) {
                     "Sets the web reporter server port. (The default port number is 8080.)",
                     false, 8080);
     cmd.add("recursive", 'r',
-            "Searches into subfolders for plugins or XML files. (Can be used with --tests or --suits options.)");
+            "Searches into subfolders for plugins or XML files. (Can be used with --tests or --suites options.)");
     cmd.add("detail", 'd',
             "Enables verbose mode of test assertions.");
     cmd.add("verbose", 'v',
@@ -163,17 +163,17 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    // exit if no test or suit is given
+    // exit if no test or suite is given
     if(!cmd.get<string>("test").size() &&
             !cmd.get<string>("tests").size() &&
-            !cmd.get<string>("suit").size() &&
-            !cmd.get<string>("suits").size()) {
+            !cmd.get<string>("suite").size() &&
+            !cmd.get<string>("suites").size()) {
         cout<<cmd.usage();
-		return EXIT_FAILURE;
+        return EXIT_FAILURE;
     }
 
     // create a test runner
-    SuitRunner runner(cmd.exist("verbose"));
+    SuiteRunner runner(cmd.exist("verbose"));
     currentRunner = &runner;
 
     // load a single plugin
@@ -195,15 +195,15 @@ int main(int argc, char *argv[]) {
         }
 
     // load a single suit
-    if(cmd.get<string>("suit").size())
-        if(!runner.loadSuit(cmd.get<string>("suit"))) {
+    if(cmd.get<string>("suite").size())
+        if(!runner.loadSuite(cmd.get<string>("suite"))) {
             reportErrors();
             return EXIT_FAILURE;
         }
 
-    // load multiple suits
-    if(cmd.get<string>("suits").size())
-        if(!runner.loadMultipleSuits(cmd.get<string>("suits"),
+    // load multiple suites
+    if(cmd.get<string>("suites").size())
+        if(!runner.loadMultipleSuites(cmd.get<string>("suites"),
                                        cmd.exist("recursive"))) {
             reportErrors();
             return EXIT_FAILURE;
@@ -266,10 +266,10 @@ int main(int argc, char *argv[]) {
     if(!cmd.exist("no-summary")) {
         // print out some simple statistics
         cout<<endl<<"---------- results -----------"<<endl;
-        if(collector.suitCount()) {
-        cout<<"Total number of test suites  : "<<collector.suitCount()<<endl;
-        cout<<"Number of passed test suites : "<<collector.passedSuitCount()<<endl;
-        cout<<"Number of failed test suites : "<<collector.failedSuitCount()<<endl;
+        if(collector.suiteCount()) {
+        cout<<"Total number of test suites  : "<<collector.suiteCount()<<endl;
+        cout<<"Number of passed test suites : "<<collector.passedSuiteCount()<<endl;
+        cout<<"Number of failed test suites : "<<collector.failedSuiteCount()<<endl;
         }
         cout<<"Total number of test cases   : "<<collector.testCount()<<endl;
         cout<<"Number of passed test cases  : "<<collector.passedCount()<<endl;
@@ -280,7 +280,7 @@ int main(int argc, char *argv[]) {
 
     int exitCode;
     if( (collector.failedCount() == 0)  &&
-        (collector.failedSuitCount() == 0))
+        (collector.failedSuiteCount() == 0))
         exitCode = EXIT_SUCCESS;
     else
         exitCode = EXIT_FAILURE;

--- a/src/testrunner/src/main.cpp
+++ b/src/testrunner/src/main.cpp
@@ -65,6 +65,14 @@ void addOptions(cmdline::parser &cmd) {
                     "Runs multiple test suites from the given folder which contains XML files.",
                     false);
 
+    cmd.add<string>("suit", '\0',
+                    "Runs a single test suite from the given XMl file (legacy option that will be removed in RTF 1.5, do not use).",
+                    false);
+
+    cmd.add<string>("suits", '\0',
+                    "Runs multiple test suites from the given folder which contains XML files (legacy option that will be removed in RTF 1.5, do not use).",
+                    false);
+
     cmd.add("no-output", '\0',
             "Avoids generating any output file");
 
@@ -167,7 +175,9 @@ int main(int argc, char *argv[]) {
     if(!cmd.get<string>("test").size() &&
             !cmd.get<string>("tests").size() &&
             !cmd.get<string>("suite").size() &&
-            !cmd.get<string>("suites").size()) {
+            !cmd.get<string>("suites").size() &&
+            !cmd.get<string>("suit").size() &&
+            !cmd.get<string>("suits").size()) {
         cout<<cmd.usage();
         return EXIT_FAILURE;
     }
@@ -194,16 +204,28 @@ int main(int argc, char *argv[]) {
             return EXIT_FAILURE;
         }
 
-    // load a single suit
-    if(cmd.get<string>("suite").size())
-        if(!runner.loadSuite(cmd.get<string>("suite"))) {
+    // load a single suite
+    string suiteFileName = cmd.get<string>("suite");
+    if(suiteFileName.empty())
+    {
+        suiteFileName = cmd.get<string>("suit");
+    }
+
+    if(suiteFileName.size())
+        if(!runner.loadSuite(suiteFileName)) {
             reportErrors();
             return EXIT_FAILURE;
         }
 
     // load multiple suites
-    if(cmd.get<string>("suites").size())
-        if(!runner.loadMultipleSuites(cmd.get<string>("suites"),
+    string suitesDirectoryName = cmd.get<string>("suites");
+    if(suitesDirectoryName.empty())
+    {
+        suitesDirectoryName = cmd.get<string>("suits");
+    }
+
+    if(suitesDirectoryName.size())
+        if(!runner.loadMultipleSuites(suitesDirectoryName,
                                        cmd.exist("recursive"))) {
             reportErrors();
             return EXIT_FAILURE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,5 +31,8 @@ if (BUILD_TESTING)
 
         # adding python tests
         add_subdirectory(ruby)
+
+        # adding testrunner tests
+        add_subdirectory(testrunner)
     endif()
 endif()

--- a/tests/basic/FixtureManager.cpp
+++ b/tests/basic/FixtureManager.cpp
@@ -13,7 +13,7 @@
 
 #include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 
 using namespace RTF;
 
@@ -74,29 +74,29 @@ public:
 
         MyTest1 test1;
 
-        // create a test suits
-        TestSuit suit("MyTestSuit");
+        // create a test suites
+        TestSuite suite("MyTestSuite");
         // create a fixture manager for the test suit
-        MyFixture fixture(&suit);
-        suit.addFixtureManager(&fixture);
-        suit.addTest(&test1);
+        MyFixture fixture(&suite);
+        suite.addFixtureManager(&fixture);
+        suite.addTest(&test1);
 
-        TestSuit suit2("MyTestSuit");
+        TestSuite suite2("MyTestSuite");
         // create a fixture manager for the test suit
-        MyFixture2 fixture2(&suit);
-        suit2.addFixtureManager(&fixture2);
-        suit2.addTest(&test1);
+        MyFixture2 fixture2(&suite);
+        suite2.addFixtureManager(&fixture2);
+        suite2.addTest(&test1);
 
         // create a test runner
         TestRunner runner;
-        runner.addTest(&suit);
-        runner.addTest(&suit2);
+        runner.addTest(&suite);
+        runner.addTest(&suite2);
         runner.run(result);
 
         //RTF_TEST_REPORT(Asserter::format("count: %d", collector.failedCount()));
-        RTF_TEST_CHECK(collector.suitCount() == 2, "Checking suit count");
-        RTF_TEST_CHECK(collector.passedSuitCount() == 1, "Checking passed suit count");
-        RTF_TEST_CHECK(collector.failedSuitCount() == 1, "Checking failed suit count");
+        RTF_TEST_CHECK(collector.suiteCount() == 2, "Checking suite count");
+        RTF_TEST_CHECK(collector.passedSuiteCount() == 1, "Checking passed suite count");
+        RTF_TEST_CHECK(collector.failedSuiteCount() == 1, "Checking failed suite count");
         RTF_TEST_CHECK(collector.testCount() == 1, "Checking tests count");
         RTF_TEST_CHECK(collector.passedCount() == 1, "Checking passed test count");
         RTF_TEST_CHECK(collector.failedCount() == 0, "Checking failed test count");

--- a/tests/basic/SingleTestSuite.cpp
+++ b/tests/basic/SingleTestSuite.cpp
@@ -13,7 +13,7 @@
 
 #include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 
 using namespace RTF;
 
@@ -47,22 +47,22 @@ public:
         TestResult result;
         result.addListener(&collector);
 
-        // create a test suit and the test cases
-        TestSuit suit("MyTestSuit");
+        // create a test suite and the test cases
+        TestSuite suite("MyTestSuite");
         MyTest1 test1;
         MyTest2 test2;
-        suit.addTest(&test1);
-        suit.addTest(&test2);
+        suite.addTest(&test1);
+        suite.addTest(&test2);
 
         // create a test runner
         TestRunner runner;
-        runner.addTest(&suit);
+        runner.addTest(&suite);
         runner.run(result);
 
         //RTF_TEST_REPORT(Asserter::format("count: %d", collector.failedCount()));
-        RTF_TEST_CHECK(collector.suitCount() == 1, "Checking suit count");
-        RTF_TEST_CHECK(collector.passedSuitCount() == 0, "Checking passed suit count");
-        RTF_TEST_CHECK(collector.failedSuitCount() == 1, "Checking failed suit count");
+        RTF_TEST_CHECK(collector.suiteCount() == 1, "Checking suite count");
+        RTF_TEST_CHECK(collector.passedSuiteCount() == 0, "Checking passed suite count");
+        RTF_TEST_CHECK(collector.failedSuiteCount() == 1, "Checking failed suite count");
         RTF_TEST_CHECK(collector.testCount() == 2, "Checking tests count");
         RTF_TEST_CHECK(collector.passedCount() == 1, "Checking passed test count");
         RTF_TEST_CHECK(collector.failedCount() == 1, "Checking failed test count");

--- a/tests/basic/WebProgListener.cpp
+++ b/tests/basic/WebProgListener.cpp
@@ -12,7 +12,7 @@
 #include <rtf/dll/Plugin.h>
 #include <rtf/WebProgressListener.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 
 #include <sstream>
 
@@ -59,16 +59,16 @@ public:
         TestResult result;
         result.addListener(&web);
 
-        // create a test suit and the test cases
-        TestSuit suit("MyTestSuit");
+        // create a test suite and the test cases
+        TestSuite suite("MyTestSuite");
         MyTest1 test1;
         MyTest2 test2;
-        suit.addTest(&test1);
-        suit.addTest(&test2);
+        suite.addTest(&test1);
+        suite.addTest(&test2);
 
         // create a test runner
         TestRunner runner;
-        runner.addTest(&suit);
+        runner.addTest(&suite);
         runner.run(result);
 
         // checking the web socket
@@ -112,7 +112,7 @@ public:
 
         RTF_TEST_CHECK(line.size()>2,"Cheking the json result size returned by web listener");
         line = line.substr(0, line.size()-1);
-        RTF_TEST_CHECK(line=="{\"name\":\"MyTestSuit\",\"ntest\":2,\"nfail\":1,\"npass\":1}",
+        RTF_TEST_CHECK(line=="{\"name\":\"MyTestSuite\",\"ntest\":2,\"nfail\":1,\"npass\":1}",
                        "Cheking the json result returned by web listener");
         close(sockfd);
     }

--- a/tests/fixture/FixturePluginLoader.cpp
+++ b/tests/fixture/FixturePluginLoader.cpp
@@ -15,7 +15,7 @@
 
 #include <rtf/TestResultCollector.h>
 #include <rtf/TestRunner.h>
-#include <rtf/TestSuit.h>
+#include <rtf/TestSuite.h>
 #include <rtf/dll/DllFixturePluginLoader.h>
 
 using namespace RTF;
@@ -30,30 +30,30 @@ public:
     }
 };
 
-class MyTestSuit : public TestSuit {
+class MyTestSuite : public TestSuite {
 public:
-	MyTestSuit() : TestSuit("MyTestSuit") { }
+    MyTestSuite() : TestSuite("MyTestSuite") { }
 
-	virtual void fixtureCollapsed(RTF::TestMessage reason) {
-		colapseReason = reason.getMessage();
-	}
-public: 
-	std::string colapseReason;
+    virtual void fixtureCollapsed(RTF::TestMessage reason) {
+        colapseReason = reason.getMessage();
+    }
+public:
+    std::string colapseReason;
 };
 
 class MyFixturePluginLoader : public RTF::TestCase {
-	std::string fixtureFilename;
+    std::string fixtureFilename;
 
 public:
-	MyFixturePluginLoader() : TestCase("FixturePluginLoader") {}
+    MyFixturePluginLoader() : TestCase("FixturePluginLoader") {}
 
-	virtual bool setup(int argc, char**argv)  {
-		RTF_TEST_REPORT(Asserter::format("argc %d", argc));
-		RTF_ASSERT_ERROR_IF(argc >= 1, "missing fixture filename in the paramater");
-		fixtureFilename = argv[1];
-		RTF_TEST_REPORT(fixtureFilename);
-		return true;
-	}
+    virtual bool setup(int argc, char**argv)  {
+        RTF_TEST_REPORT(Asserter::format("argc %d", argc));
+        RTF_ASSERT_ERROR_IF(argc >= 1, "missing fixture filename in the paramater");
+        fixtureFilename = argv[1];
+        RTF_TEST_REPORT(fixtureFilename);
+        return true;
+    }
 
     virtual void run() {
         TestResultCollector collector;
@@ -64,54 +64,54 @@ public:
 
         MyTest1 test1;
 
-        // create a test suits
-        MyTestSuit suit;
+        // create a test suites
+        MyTestSuite suite;
 
         // create a fixture manager from the plugin for the test suit
-		RTF_TEST_REPORT(Asserter::format("Loading the fixture manager plugin (%s)", fixtureFilename.c_str()));
-		DllFixturePluginLoader* loader = new DllFixturePluginLoader();
-		FixtureManager* fixture = loader->open(fixtureFilename);
-		RTF_ASSERT_FAIL_IF(fixture, loader->getLastError());
+        RTF_TEST_REPORT(Asserter::format("Loading the fixture manager plugin (%s)", fixtureFilename.c_str()));
+        DllFixturePluginLoader* loader = new DllFixturePluginLoader();
+        FixtureManager* fixture = loader->open(fixtureFilename);
+        RTF_ASSERT_FAIL_IF(fixture, loader->getLastError());
 
-        suit.addFixtureManager(fixture);		
-        suit.addTest(&test1);
+        suite.addFixtureManager(fixture);
+        suite.addTest(&test1);
 
-		RTF_TEST_FAIL_IF(fixture->getDispatcher() == (RTF::FixtureEvents*)(&suit), "FixtureEvents dispatcher is not set");
-		fixture->setParam("MY_FIXTURE_TEST_PARAM");
+        RTF_TEST_FAIL_IF(fixture->getDispatcher() == (RTF::FixtureEvents*)(&suite), "FixtureEvents dispatcher is not set");
+        fixture->setParam("MY_FIXTURE_TEST_PARAM");
 
         // create a test runner
         TestRunner runner;
-        runner.addTest(&suit);
+        runner.addTest(&suite);
         runner.run(result);
-		
-		RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_SETUP") != NULL &&
-			std::string(getenv("MY_FIXTURE_TEST_SETUP")) == "OK",
-			"Checking FixtureManager::setup()");
 
-		RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_CHECK") != NULL &&
-			std::string(getenv("MY_FIXTURE_TEST_CHECK")) == "OK",
-			"Checking FixtureManager::check()");
+        RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_SETUP") != NULL &&
+            std::string(getenv("MY_FIXTURE_TEST_SETUP")) == "OK",
+            "Checking FixtureManager::setup()");
 
-		RTF_TEST_CHECK(suit.colapseReason == "COLAPSED", "FixtureManager::fixtureCollapsed()");
+        RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_CHECK") != NULL &&
+            std::string(getenv("MY_FIXTURE_TEST_CHECK")) == "OK",
+            "Checking FixtureManager::check()");
 
-		RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_TEARDOWN") != NULL &&
-			std::string(getenv("MY_FIXTURE_TEST_TEARDOWN")) == "OK",
-			"Checking FixtureManager::tearDown()");
+        RTF_TEST_CHECK(suite.colapseReason == "COLAPSED", "FixtureManager::fixtureCollapsed()");
 
-//		delete fixture;
-//		delete loader;
-//		RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_DELETE") != NULL &&
-//			std::string(getenv("MY_FIXTURE_TEST_DELETE")) == "OK",
-//			"Checking deleteing FixtureManager");
+        RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_TEARDOWN") != NULL &&
+            std::string(getenv("MY_FIXTURE_TEST_TEARDOWN")) == "OK",
+            "Checking FixtureManager::tearDown()");
 
-        //RTF_TEST_REPORT(Asserter::format("count: %d", collector.failedCount()));		
-        RTF_TEST_CHECK(collector.suitCount() == 1, "Checking suit count");
-        RTF_TEST_CHECK(collector.passedSuitCount() == 1, "Checking passed suit count");
-        RTF_TEST_CHECK(collector.failedSuitCount() == 0, "Checking failed suit count");
+//        delete fixture;
+//        delete loader;
+//        RTF_TEST_CHECK(getenv("MY_FIXTURE_TEST_DELETE") != NULL &&
+//            std::string(getenv("MY_FIXTURE_TEST_DELETE")) == "OK",
+//            "Checking deleteing FixtureManager");
+
+        //RTF_TEST_REPORT(Asserter::format("count: %d", collector.failedCount()));
+        RTF_TEST_CHECK(collector.suiteCount() == 1, "Checking suite count");
+        RTF_TEST_CHECK(collector.passedSuiteCount() == 1, "Checking passed suite count");
+        RTF_TEST_CHECK(collector.failedSuiteCount() == 0, "Checking failed suite count");
         RTF_TEST_CHECK(collector.testCount() == 1, "Checking tests count");
         RTF_TEST_CHECK(collector.passedCount() == 1, "Checking passed test count");
         RTF_TEST_CHECK(collector.failedCount() == 0, "Checking failed test count");
-		
+
     }
 };
 

--- a/tests/fixture/MyFixManager.cpp
+++ b/tests/fixture/MyFixManager.cpp
@@ -20,22 +20,22 @@ using namespace RTF;
 PREPARE_FIXTURE_PLUGIN(MyFixManager)
 
 bool MyFixManager::setup(int argc, char** argv) {
-	RTF_ASSERT_ERROR_IF(argc >= 1, "missing paramter MY_FIXTURE_TEST_PARAM");
-	RTF_ASSERT_ERROR_IF(string(argv[0]) == string("MY_FIXTURE_TEST_PARAM"), "missing paramter MY_FIXTURE_TEST_PARAM");
-	RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_SETUP=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_SETUP");
+    RTF_ASSERT_ERROR_IF(argc >= 1, "missing paramter MY_FIXTURE_TEST_PARAM");
+    RTF_ASSERT_ERROR_IF(string(argv[0]) == string("MY_FIXTURE_TEST_PARAM"), "missing paramter MY_FIXTURE_TEST_PARAM");
+    RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_SETUP=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_SETUP");
     return true;
 }
 
 bool MyFixManager::check() {
-	RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_CHECK=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_CHECK");
-	return true;
+    RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_CHECK=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_CHECK");
+    return true;
 }
 
 void MyFixManager::tearDown() {
-	getDispatcher()->fixtureCollapsed(TestMessage("COLAPSED"));
-	RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_TEARDOWN=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_TEARDOWN");    
+    getDispatcher()->fixtureCollapsed(TestMessage("COLAPSED"));
+    RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_TEARDOWN=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_TEARDOWN");
 }
 
 MyFixManager::~MyFixManager() {
-	// RTF_ASSERT_ERROR_IF(putenv("MY_FIXTURE_TEST_DELETE=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_DELETE");
+    // RTF_ASSERT_ERROR_IF(putenv("MY_FIXTURE_TEST_DELETE=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_DELETE");
 }

--- a/tests/fixture/MyFixManager.h
+++ b/tests/fixture/MyFixManager.h
@@ -14,12 +14,12 @@
 
 class MyFixManager : public RTF::FixtureManager {
 public:
-	MyFixManager() { }
-	virtual ~MyFixManager();
+    MyFixManager() { }
+    virtual ~MyFixManager();
 
     virtual bool setup(int argc, char** argv);
 
-	virtual bool check();
+    virtual bool check();
 
     virtual void tearDown();
 

--- a/tests/testrunner/CMakeLists.txt
+++ b/tests/testrunner/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+#  Robot Testing Framework
+#  Copyright: (C) 2017 iCub Facility, Istituto Italiano di Tecnologia
+#  Authors: Silvio Traversaro <silvio@traversaro.it>
+#
+#  Copy Policy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+#
+
+
+# adding testrunner tests
+add_test(NAME TestRunnerLoadSimpleSuite
+         COMMAND $<TARGET_FILE:testrunner> -v --no-output --suite ${CMAKE_CURRENT_SOURCE_DIR}/testsuite.xml
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_test(NAME TestRunnerLoadLegacySuit
+         COMMAND $<TARGET_FILE:testrunner> -v --no-output --suit ${CMAKE_CURRENT_SOURCE_DIR}/testsuit.xml
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/testrunner/testsuit.xml
+++ b/tests/testrunner/testsuit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suit name="test suite">
+    <description> a simple test suite, but using the deprecated suit tag</description>
+    <environment></environment>
+</suit>
+

--- a/tests/testrunner/testsuite.xml
+++ b/tests/testrunner/testsuite.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="test suite">
+    <description> a simple test suite</description>
+    <environment></environment>
+</suite>
+


### PR DESCRIPTION
### Warning: breaking change

I don't think it is worth supporting both the **suit** and **suite** syntax in the xml parsing and in the arguments, it would require a lot of effort just to support a typo. I suggest we just break compatibility now instead.

in master we can ensure that the RTF version is ok by changing:

```diff
-find_package(RTF 1.2)
+find_package(RTF 1.2 EXACT)
```

in devel we can change it to
```diff
-find_package(RTF 1.2)
+find_package(RTF 1.3)
```
