### PR TITLE
Add win32, win64 configurations and tests to appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,37 @@
 version: 1.2.{build}
 
+platform:
+  - Win32
+  - x64
+
+image:
+ - Visual Studio 2013
+ - Visual Studio 2015
+ - Visual Studio 2017
+
+configuration:
+  - Release
+  #- Debug #on master the plugin loader is bugged(missing "d" in the dll name)
+
+environment:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
 clone_folder: c:\dev\RTF
+
+init:
+  # System related variables
+  - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set CMAKE_GENERATOR=Visual Studio 15 2017
+  - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" set CMAKE_GENERATOR=Visual Studio 14 2015
+  - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" set CMAKE_GENERATOR=Visual Studio 12 2013
+  - cmd: if "%platform%"=="x64" set CMAKE_GENERATOR=%CMAKE_GENERATOR% Win64
+  - cmd: echo CMAKE_GENERATOR=%CMAKE_GENERATOR%
 
 build_script:
   - cd c:\dev\RTF
   - md build
   - cd build
-  - cmake -G"Visual Studio 12" ..
-  - msbuild /m /p:Configuration=Release /p:Platform="Win32" RTF.sln
+  - cmake -G"%CMAKE_GENERATOR%" ..
+  - msbuild /m /p:Configuration="%CONFIGURATION%" /p:Platform="%platform%" RTF.sln
+
+test_script:
+  - cmd: cmake --build %APPVEYOR_BUILD_FOLDER%\build --target RUN_TESTS --config %CONFIGURATION%


### PR DESCRIPTION
This PR enables tests, Win32, Win64, visual studio 2013, 2015 and 2017 in appveyor