### PR TITLE
Unify SharedLibrary classes api

### DIFF
--- a/doc/release/v1_4_0.md
+++ b/doc/release/v1_4_0.md
@@ -35,6 +35,10 @@ Bug Fixes
   in debug configuration rtf will try to load the dll 
   with a "d" between the name and the format
   (e.g. name + "d" + .dll)
+* `SharedLibrary*` classes unified with respective
+  `YARP` code. In particular commit c114635 has been
+  imported from YARP. See issue #435 in robotology/yarp
+  for more details.
 
 Contributors
 ------------

--- a/src/plugins/dll/include/rtf/dll/SharedLibrary.h
+++ b/src/plugins/dll/include/rtf/dll/SharedLibrary.h
@@ -1,7 +1,6 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /*
- * Copyright (C) 2011 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
+ * Copyright (C) 2011 Istituto Italiano di Tecnologia (IIT)
  * Authors: Paul Fitzpatrick
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  *
@@ -57,6 +56,14 @@ public:
     bool close();
 
     /**
+     * Returns a human-readable string describing the most recent error that
+     * occurred from a call to one of its functions.
+     *
+     * @return the most recent error
+     */
+    std::string error();
+
+    /**
      * Look up a symbol in the shared library.
      */
     void *getSymbol(const char *symbolName);
@@ -67,12 +74,6 @@ public:
      * @return true iff a valid library has been loaded.
      */
     bool isValid() const;
-
-    /**
-     * Get Last error message reported by the Os (if presented)
-     * @return return error message
-     */
-    std::string getLastNativeError() const;
 
 private:
     void *implementation;

--- a/src/plugins/dll/include/rtf/dll/SharedLibraryClass.h
+++ b/src/plugins/dll/include/rtf/dll/SharedLibraryClass.h
@@ -1,7 +1,6 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /*
- * Copyright (C) 2011 Department of Robotics Brain and Cognitive Sciences - Istituto Italiano di Tecnologia
+ * Copyright (C) 2011 Istituto Italiano di Tecnologia (IIT)
  * Authors: Paul Fitzpatrick
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  *
@@ -112,7 +111,7 @@ public:
      * @return true iff a valid instance has been created
      */
     bool isValid() const {
-        return content!=0/*nullptr*/;
+        return content != nullptr;
     }
 
     /**

--- a/src/plugins/dll/include/rtf/dll/SharedLibraryClassApi.h
+++ b/src/plugins/dll/include/rtf/dll/SharedLibraryClassApi.h
@@ -1,20 +1,15 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
-
 /*
- * Copyright (C) 2013 iCub Facility
+ * Copyright (C) 2013 Istituto Italiano di Tecnologia (IIT)
  * Authors: Paul Fitzpatrick
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
 #ifndef _SHLIBPP_SHLIBPPLIBRARYCLASSAPI_
 #define _SHLIBPP_SHLIBPPLIBRARYCLASSAPI_
 
-#include <string.h>
-#include <string>
-
 #include "rtf_dll_config.h"
 
+#include <cstring>
 
 namespace shlibpp {
     struct SharedLibraryClassApi;   
@@ -71,32 +66,47 @@ extern "C" {
  * working with.
  *
  */
-#define SHLIBPP_DEFINE_SHARED_SUBCLASS(factoryname,classname,basename)       \
-    SHLIBPP_SHARED_CLASS_FN void *factoryname ## _create () { return (basename *)new classname; } \
-    SHLIBPP_SHARED_CLASS_FN void factoryname ## _destroy (void *obj) { delete (classname *)obj; } \
-    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getVersion (char *ver, int len) { return 0; }   \
-    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getAbi (char *abi, int len) { return 0; }       \
-    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getClassName (char *name, int len) { char cname[] = # classname; strncpy(name,cname,len); return strlen(cname)+1; } \
-    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getBaseClassName (char *name, int len) { char cname[] = # basename; strncpy(name,cname,len); return strlen(cname)+1; } \
-    SHLIBPP_SHARED_CLASS_FN int factoryname(void *api,int len) { \
-    struct shlibpp::SharedLibraryClassApi *sapi = (struct shlibpp::SharedLibraryClassApi *) api; \
-    if (len<(int)sizeof(shlibpp::SharedLibraryClassApi)) return -1;    \
-    sapi->startCheck = VOCAB4('S','H','P','P'); \
-    sapi->structureSize = sizeof(shlibpp::SharedLibraryClassApi);  \
-    sapi->systemVersion = 3; \
-    sapi->create = factoryname ## _create; \
-    sapi->destroy = factoryname ## _destroy; \
-    sapi->getVersion = factoryname ## _getVersion; \
-    sapi->getAbi = factoryname ## _getAbi; \
-    sapi->getClassName = factoryname ## _getClassName; \
-    sapi->getBaseClassName = factoryname ## _getBaseClassName; \
-    for (int i=0; i<SHLIBPP_SHAREDLIBRARYCLASSAPI_PADDING; i++) { sapi->roomToGrow[i] = 0; } \
-    sapi->endCheck = VOCAB4('P','L','U','G');        \
-    return sapi->startCheck;                    \
+#define SHLIBPP_DEFINE_SHARED_SUBCLASS(factoryname, classname, basename) \
+    SHLIBPP_SHARED_CLASS_FN void *factoryname ## _create () { \
+        classname *cn = new classname; \
+        basename *bn = dynamic_cast<basename *>(cn); \
+        if (!bn) delete cn; \
+        return static_cast<void *>(bn); \
+    } \
+    SHLIBPP_SHARED_CLASS_FN void factoryname ## _destroy (void *obj) { delete dynamic_cast<classname *>(static_cast<basename *>(obj)); } \
+    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getVersion (char *ver, int len) { return 0; } \
+    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getAbi (char *abi, int len) { return 0; } \
+    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getClassName (char *name, int len) { char cname[] = # classname; strncpy(name, cname, len); return strlen(cname)+1; } \
+    SHLIBPP_SHARED_CLASS_FN int factoryname ## _getBaseClassName (char *name, int len) { char cname[] = # basename; strncpy(name, cname, len); return strlen(cname)+1; } \
+    SHLIBPP_SHARED_CLASS_FN int factoryname(void *api, int len) { \
+        struct shlibpp::SharedLibraryClassApi *sapi = (struct shlibpp::SharedLibraryClassApi *) api; \
+        if (len<(int)sizeof(shlibpp::SharedLibraryClassApi)) return -1; \
+        sapi->startCheck = VOCAB4('S','H','P','P'); \
+        sapi->structureSize = sizeof(shlibpp::SharedLibraryClassApi); \
+        sapi->systemVersion = 5; \
+        sapi->create = factoryname ## _create; \
+        sapi->destroy = factoryname ## _destroy; \
+        sapi->getVersion = factoryname ## _getVersion; \
+        sapi->getAbi = factoryname ## _getAbi; \
+        sapi->getClassName = factoryname ## _getClassName; \
+        sapi->getBaseClassName = factoryname ## _getBaseClassName; \
+        for (int i=0; i<SHLIBPP_SHAREDLIBRARYCLASSAPI_PADDING; i++) { sapi->roomToGrow[i] = 0; } \
+        sapi->endCheck = VOCAB4('P', 'L', 'U', 'G'); \
+        return sapi->startCheck; \
     }
+// The double cast in the _create() and _destroy() functions are
+// required to ensure that everything works when `basename` is not the
+// first inherited class:
+// _create() will return a valid `basename` or a null pointer if
+// `classname` does not inherit from `basename`.
+// _destroy() will ensure that we are calling `classname` destructor
+// even if `basename` is not the first inherited class. If the
+// dynamic_cast fails, it will not delete the object (that is probably
+// leaked), but it is less dangerous than executing some other random
+// function.
 
 #define SHLIBPP_DEFAULT_FACTORY_NAME "shlibpp_default_factory"
-#define SHLIBPP_DEFINE_DEFAULT_SHARED_CLASS(classname) SHLIBPP_DEFINE_SHARED_SUBCLASS(shlibpp_default_factory,classname,classname)
-#define SHLIBPP_DEFINE_SHARED_CLASS(factoryname,classname) SHLIBPP_DEFINE_SHARED_SUBCLASS(factoryname,classname,classname)
+#define SHLIBPP_DEFINE_DEFAULT_SHARED_CLASS(classname) SHLIBPP_DEFINE_SHARED_SUBCLASS(shlibpp_default_factory, classname, classname)
+#define SHLIBPP_DEFINE_SHARED_CLASS(factoryname, classname) SHLIBPP_DEFINE_SHARED_SUBCLASS(factoryname, classname, classname)
 
 #endif

--- a/src/plugins/dll/include/rtf/dll/SharedLibraryClassFactory.h
+++ b/src/plugins/dll/include/rtf/dll/SharedLibraryClassFactory.h
@@ -1,7 +1,6 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /*
- * Copyright (C) 2013 iCub Facility
+ * Copyright (C) 2013 Istituto Italiano di Tecnologia (IIT)
  * Authors: Paul Fitzpatrick
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  *
@@ -36,7 +35,7 @@ public:
     }
 
     T *create() {
-        if (!isValid()) return 0/*nullptr*/;
+        if (!isValid()) return nullptr;
         return (T *)getApi().create();
     }
 

--- a/src/plugins/dll/include/rtf/dll/SharedLibraryFactory.h
+++ b/src/plugins/dll/include/rtf/dll/SharedLibraryFactory.h
@@ -1,10 +1,8 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /*
- * Copyright (C) 2013 iCub Facility
- * Authors: Paul Fitzpatrick
+ * Copyright (C) 2013 Istituto Italiano di Tecnologia (IIT)
+ * Authors: Paul Fitzpatrick <paulfitz@alum.mit.edu>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
 #ifndef _SHLIBPP_YARPSHAREDLIBRARYFACTORY_
@@ -32,6 +30,7 @@ public:
      * The status of a factory can be:
      *  - STATUS_NONE: Not configured yet
      *  - STATUS_OK: Present and sane
+     *  - STATUS_LIBRARY_NOT_FOUND: Named shared library was not found
      *  - STATUS_LIBRARY_NOT_LOADED: Named shared library failed to load
      *  - STATUS_FACTORY_NOT_FOUND: Named method wasn't present in library
      *  - STATUS_FACTORY_NOT_FUNCTIONAL: Named method is not working right
@@ -39,6 +38,7 @@ public:
     enum {
         STATUS_NONE,                                         //!< Not configured yet.
         STATUS_OK = VOCAB2('o','k'),                         //!< Present and sane.
+        STATUS_LIBRARY_NOT_FOUND = VOCAB4('f', 'o', 'u', 'n'),  //!< Named shared library was not found.
         STATUS_LIBRARY_NOT_LOADED = VOCAB4('l','o','a','d'), //!< Named shared library failed to load.
         STATUS_FACTORY_NOT_FOUND = VOCAB4('f','a','c','t'),  //!< Named method wasn't present in library.
         STATUS_FACTORY_NOT_FUNCTIONAL = VOCAB3('r','u','n') //!< Named method is not working right.
@@ -87,6 +87,14 @@ public:
     int getStatus() const;
 
     /**
+     * Get the latest error of the factory.
+     *
+     * @return the latest error.
+     */
+    std::string getError() const;
+
+    /**
+
      * Get the factory API, which has creation/deletion methods.
      *
      * @return the factory API
@@ -122,6 +130,20 @@ public:
     std::string getName() const;
 
     /**
+     * Get the type associated with this factory.
+     *
+     * @return the type associated with this factory.
+     */
+    std::string getClassName() const;
+
+    /**
+     * Get the base type associated with this factory.
+     *
+     * @return the base type associated with this factory.
+     */
+    std::string getBaseClassName() const;
+
+    /**
      *
      * Specify function to use as factory.
      *
@@ -132,12 +154,6 @@ public:
      */
     bool useFactoryFunction(void *factory);
 
-    /**
-     * Get Last error message reported by the Os (if presented)
-     * @return return error message
-     */
-    std::string getLastNativeError() const;
-
 private:
     SharedLibrary lib;
     int status;
@@ -145,7 +161,9 @@ private:
     int returnValue;
     int rct;
     std::string name;
-    std::string err_message;
+    std::string className;
+    std::string baseClassName;
+    std::string error;
 };
 
 

--- a/src/plugins/dll/include/rtf/dll/impl/DllPluginLoader_impl.h
+++ b/src/plugins/dll/include/rtf/dll/impl/DllPluginLoader_impl.h
@@ -68,8 +68,8 @@ public:
             }
             else {
                 error = "cannot load plugin " + filename + "; error (" +
-                    shlibpp::Vocab::decode(plugin->factory.getStatus()) + ") : " +
-                    plugin->factory.getLastNativeError();
+                        shlibpp::Vocab::decode(plugin->factory.getStatus()) + ") : " +
+                        plugin->factory.getError();
             }
             delete plugin;
             plugin = nullptr;

--- a/src/plugins/dll/src/SharedLibraryFactory.cpp
+++ b/src/plugins/dll/src/SharedLibraryFactory.cpp
@@ -61,7 +61,7 @@ bool shlibpp::SharedLibraryFactory::isValid() const {
     if (api.structureSize != sizeof(SharedLibraryClassApi)) {
         return false;
     }
-    if (api.systemVersion != 3) {
+    if (api.systemVersion != 5) {
         return false;
     }
     if (api.endCheck != VOCAB4('P','L','U','G')) {

--- a/src/plugins/dll/src/SharedLibraryFactory.cpp
+++ b/src/plugins/dll/src/SharedLibraryFactory.cpp
@@ -1,57 +1,83 @@
-// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
 
 /*
- * Copyright (C) 2013 iCub Facility
- * Authors: Paul Fitzpatrick
+ * Copyright (C) 2013 Istituto Italiano di Tecnologia (IIT)
+ * Authors: Paul Fitzpatrick <paulfitz@alum.mit.edu>
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
- *
  */
 
 #include <rtf/dll/SharedLibraryFactory.h>
+#include <sys/stat.h>
 
 shlibpp::SharedLibraryFactory::SharedLibraryFactory() :
         status(STATUS_NONE),
         returnValue(0),
-        rct(1) {
+        rct(1)
+{
 }
 
 shlibpp::SharedLibraryFactory::SharedLibraryFactory(const char *dll_name,
                                                      const char *fn_name) :
         status(STATUS_NONE),
         returnValue(0),
-        rct(1) {
+        rct(1)
+{
     open(dll_name,fn_name);
 }
 
-shlibpp::SharedLibraryFactory::~SharedLibraryFactory() {
+shlibpp::SharedLibraryFactory::~SharedLibraryFactory()
+{
 }
 
-bool shlibpp::SharedLibraryFactory::open(const char *dll_name, const char *fn_name) {
+bool shlibpp::SharedLibraryFactory::open(const char *dll_name, const char *fn_name)
+{
     returnValue = 0;
     name = "";
+    className = "";
+    baseClassName = "";
     status = STATUS_NONE;
+    error = "";
     api.startCheck = 0;
     if (!lib.open(dll_name)) {
-        status = STATUS_LIBRARY_NOT_LOADED;
+#if defined(_WIN32)
+        struct _stat dummy;
+        if (::_stat(dll_name, &dummy) != 0) {
+#else
+        struct ::stat dummy;
+        if (::stat(dll_name, &dummy) != 0) {
+#endif
+            status = STATUS_LIBRARY_NOT_FOUND;
+        } else {
+            status = STATUS_LIBRARY_NOT_LOADED;
+        }
+        error = lib.error();
         return false;
     }
-    void *fn = lib.getSymbol((fn_name!=0/*nullptr*/)?fn_name:SHLIBPP_DEFAULT_FACTORY_NAME);
-    if (fn==0/*nullptr*/) {
-        lib.close();
+    void *fn = lib.getSymbol((fn_name != nullptr)?fn_name:SHLIBPP_DEFAULT_FACTORY_NAME);
+    if (fn == nullptr) {
         status = STATUS_FACTORY_NOT_FOUND;
+        error = lib.error();
+        lib.close();
         return false;
     }
-    useFactoryFunction(fn);
-    if (!isValid()) {
+    if (!useFactoryFunction(fn)) {
         status = STATUS_FACTORY_NOT_FUNCTIONAL;
+        error = "RTF hook in shared library misbehaved";
         return false;
     }
     status = STATUS_OK;
     name = dll_name;
+
+    char buf[256];
+    api.getClassName(buf, 256);
+    className = buf;
+    api.getBaseClassName(buf, 256);
+    baseClassName = buf;
+
     return true;
 }
 
-bool shlibpp::SharedLibraryFactory::isValid() const {
+bool shlibpp::SharedLibraryFactory::isValid() const
+{
     if (returnValue != VOCAB4('S','H','P','P')) {
         return false;
     }
@@ -70,44 +96,63 @@ bool shlibpp::SharedLibraryFactory::isValid() const {
     return true;
 }
 
-int shlibpp::SharedLibraryFactory::getStatus() const {
+int shlibpp::SharedLibraryFactory::getStatus() const
+{
     return status;
 }
-const shlibpp::SharedLibraryClassApi& shlibpp::SharedLibraryFactory::getApi() const {
+
+std::string shlibpp::SharedLibraryFactory::getError() const
+{
+    return error;
+}
+
+const shlibpp::SharedLibraryClassApi& shlibpp::SharedLibraryFactory::getApi() const
+{
     return api;
 }
 
-int shlibpp::SharedLibraryFactory::getReferenceCount() const {
+
+int shlibpp::SharedLibraryFactory::getReferenceCount() const
+{
     return rct;
 }
 
 
-int shlibpp::SharedLibraryFactory::addRef() {
+int shlibpp::SharedLibraryFactory::addRef()
+{
     rct++;
     return rct;
 }
 
-int shlibpp::SharedLibraryFactory::removeRef() {
+int shlibpp::SharedLibraryFactory::removeRef()
+{
     rct--;
     return rct;
 }
 
-std::string shlibpp::SharedLibraryFactory::getName() const {
+std::string shlibpp::SharedLibraryFactory::getName() const
+{
     return name;
 }
 
 
-std::string shlibpp::SharedLibraryFactory::getLastNativeError() const {
-    return lib.getLastNativeError();
+std::string shlibpp::SharedLibraryFactory::getClassName() const
+{
+    return className;
+}
+
+std::string shlibpp::SharedLibraryFactory::getBaseClassName() const
+{
+    return baseClassName;
 }
 
 
-bool shlibpp::SharedLibraryFactory::useFactoryFunction(void *factory) {
+bool shlibpp::SharedLibraryFactory::useFactoryFunction(void *factory)
+{
     api.startCheck = 0;
     if (factory == nullptr) {
         return false;
     }
-    isValid();
     returnValue =
         ((int (*)(void *ptr,int len)) factory)(&api,sizeof(SharedLibraryClassApi));
     return isValid();


### PR DESCRIPTION
This PR unifies RTF `SharedLibrary*` classes with the respective `yarp::os::SharedLibrary*`, excluding the part with ACE because RTF doesn't depend from it.
In particular it imports the commit c114635 made by @drdanz on `YARP`. 

As soon as it passes the tests, it can be merged.