### PR TITLE
Add target_include_directories and rtf_add_plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@ set(INSTALL_RTF_RUBY_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
 install_basic_package_files(${PROJECT_NAME}
                             VERSION ${RTF_VERSION}
                             COMPATIBILITY AnyNewerVersion
-                            TARGETS_PROPERTY RTF_LIBS
+                            TARGETS_PROPERTIES RTF_LIBS
+                                               RTF_TOOLS
                             EXTRA_PATH_VARS_SUFFIX DLL_INCLUDEDIR
                                                    LUA_INCLUDEDIR
                                                    PYTHON_INCLUDEDIR

--- a/RTFConfig.cmake.in
+++ b/RTFConfig.cmake.in
@@ -56,3 +56,34 @@ endif()
 
 check_required_components(RTF)
 
+################################################################################
+#.rst:
+# .. command:: rtf_add_plugin
+#
+# Declare a plugin::
+#
+#   rtf_add_plugin(<plugin name>
+#                       OUTPUT_NAME <output_name>
+#                       srcs
+#                       hdrs)
+#
+# This macro converts a plugin declaration to code, and to set up a CMake option
+# for enabling or disabling the compilation of that plugin.
+#
+# The ``OUTPUT_NAME`` is the base name for output files created for the library target.
+
+macro(RTF_ADD_PLUGIN _library_name)
+
+  set(_options)
+  set(_oneValueArgs OUTPUT_NAME)
+  set(_multiValueArgs)
+  cmake_parse_arguments(_RAP "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN} )
+
+  add_library(${_library_name} MODULE ${_RAP_UNPARSED_ARGUMENTS})
+  target_link_libraries(${_library_name} RTF::RTF
+                                         RTF::RTF_dll)
+  set_property(TARGET ${_library_name} PROPERTY PREFIX "")
+  if(DEFINED _RAP_OUTPUT_NAME)
+    set_property(TARGET ${_library_name} PROPERTY OUTPUT_NAME ${_RAP_OUTPUT_NAME})
+  endif()
+endmacro()

--- a/conf/InstallBasicPackageFiles.cmake
+++ b/conf/InstallBasicPackageFiles.cmake
@@ -15,6 +15,7 @@
 #                              VERSION <version>
 #                              COMPATIBILITY <compatibility>
 #                              TARGETS_PROPERTY <property_name>
+#                              TARGETS_PROPERTIES <property1_name> <property1_name>
 #                              [NO_SET_AND_CHECK_MACRO]
 #                              [NO_CHECK_REQUIRED_COMPONENTS_MACRO]
 #                              [VARS_PREFIX <prefix>] # (default = "<name>")
@@ -148,7 +149,8 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
                       VARS_PREFIX
                       DESTINATION
                       NAMESPACE)
-    set(_multiValueArgs EXTRA_PATH_VARS_SUFFIX)
+    set(_multiValueArgs EXTRA_PATH_VARS_SUFFIX
+                        TARGETS_PROPERTIES)
     cmake_parse_arguments(_IBPF "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" "${ARGN}")
 
     if(NOT DEFINED _IBPF_VARS_PREFIX)
@@ -163,8 +165,12 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
         message(FATAL_ERROR "COMPATIBILITY argument is required")
     endif()
 
-    if(NOT DEFINED _IBPF_TARGETS_PROPERTY)
-        message(FATAL_ERROR "TARGETS_PROPERTY argument is required")
+    if(NOT DEFINED _IBPF_TARGETS_PROPERTY AND NOT DEFINED _IBPF_TARGETS_PROPERTIES)
+        message(FATAL_ERROR "TARGETS_PROPERTY or TARGET_PROPERTIES argument is required")
+    endif()
+
+    if(DEFINED _IBPF_TARGETS_PROPERTY AND DEFINED _IBPF_TARGETS_PROPERTIES)
+        message(FATAL_ERROR "Only one argument between TARGETS_PROPERTY or TARGET_PROPERTIES can be used")
     endif()
 
     if(_IBPF_UPPERCASE_FILENAMES AND _IBPF_LOWERCASE_FILENAMES)
@@ -252,7 +258,15 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
 
 
     # Get targets from GLOBAL PROPERTY
-    get_property(_targets GLOBAL PROPERTY ${_IBPF_TARGETS_PROPERTY})
+    if(DEFINED _IBPF_TARGETS_PROPERTY)
+        get_property(_targets GLOBAL PROPERTY ${_IBPF_TARGETS_PROPERTY})
+    else()
+        set(_targets)
+        foreach(_prop ${_IBPF_TARGETS_PROPERTIES})
+            get_property(_prop_val GLOBAL PROPERTY ${_prop})
+            list(APPEND _targets ${_prop_val})
+        endforeach()
+    endif()
     foreach(_target ${_targets})
         list(APPEND ${_IBPF_VARS_PREFIX}_TARGETS ${_Name}::${_target})
     endforeach()

--- a/doc/release/v1_4_0.md
+++ b/doc/release/v1_4_0.md
@@ -11,12 +11,19 @@ Important Changes
 * Fixed old typo, the keyword `suit` has been
   replaced with `suite`, maintaining the backward
   compatibility.
+* Added `target_include_directories` in all RTF
+  libraries.
 
 ### Libraries
 
 
 New Features
 ------------
+
+### CMake Modules
+
+* Added `rtf_add_plugin`.
+* Exported target `testrunner`.
 
 ### Libraries
 

--- a/src/plugins/dll/CMakeLists.txt
+++ b/src/plugins/dll/CMakeLists.txt
@@ -30,8 +30,13 @@ add_library(RTF_dll SHARED ${folder_source} ${folder_header} )
 if(NOT WIN32)
   target_link_libraries(RTF_dll dl)
 else()
-    target_link_libraries(RTF_dll)
+  target_link_libraries(RTF_dll)
 endif()
+
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_nullptr)
+
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 
 # choose which header files should be installed

--- a/src/plugins/lua/CMakeLists.txt
+++ b/src/plugins/lua/CMakeLists.txt
@@ -44,6 +44,11 @@ endif()
 
 target_link_libraries(RTF_lua ${RTF_LIBS} ${LUA_LIBRARY})
 
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_nullptr)
+
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 
 # choose which header files should be installed
 file(GLOB RTF_DLL_HEADERS ${PROJECT_SOURCE_DIR}/include/rtf/lua/*.h)

--- a/src/plugins/python/CMakeLists.txt
+++ b/src/plugins/python/CMakeLists.txt
@@ -49,6 +49,11 @@ endif()
 link_libraries(${PYTHON_LIBRARY})
 target_link_libraries(RTF_python ${RTF_LIBS} ${PYTHON_LIBRARY})
 
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_nullptr)
+
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 # choose which header files should be installed
 file(GLOB RTF_DLL_HEADERS ${PROJECT_SOURCE_DIR}/include/rtf/python/*.h)
 set_property(TARGET RTF_python PROPERTY PUBLIC_HEADER ${RTF_DLL_HEADERS})

--- a/src/plugins/ruby/CMakeLists.txt
+++ b/src/plugins/ruby/CMakeLists.txt
@@ -38,6 +38,11 @@ endif()
 
 target_link_libraries(RTF_ruby ${RTF_LIBS} ${RUBY_LIBRARY})
 
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_nullptr)
+
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 
 # choose which header files should be installed
 file(GLOB RTF_DLL_HEADERS ${PROJECT_SOURCE_DIR}/include/rtf/ruby/*.h)

--- a/src/rtf/CMakeLists.txt
+++ b/src/rtf/CMakeLists.txt
@@ -108,6 +108,8 @@ endif()
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_nullptr)
 
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # choose which header files should be installed
 set_property(TARGET ${PROJECT_NAME} PROPERTY PUBLIC_HEADER ${RTF_HDRS})

--- a/src/testrunner/CMakeLists.txt
+++ b/src/testrunner/CMakeLists.txt
@@ -32,6 +32,8 @@ source_group("Header Files" FILES ${folder_header})
 add_executable(${PROJECT_NAME} ${folder_source} ${folder_header})
 target_link_libraries(${PROJECT_NAME} ${RTF_LIBS} ${RTF_INTERNAL_LIBS} ${TinyXML_LIBRARIES})
 
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_nullptr)
+
 install(TARGETS ${PROJECT_NAME}
         EXPORT ${PROJECT_NAME}
         RUNTIME DESTINATION bin)

--- a/src/testrunner/CMakeLists.txt
+++ b/src/testrunner/CMakeLists.txt
@@ -37,3 +37,5 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_nullptr)
 install(TARGETS ${PROJECT_NAME}
         EXPORT ${PROJECT_NAME}
         RUNTIME DESTINATION bin)
+
+set_property(GLOBAL APPEND PROPERTY RTF_TOOLS ${PROJECT_NAME})


### PR DESCRIPTION
This PR add `add target_include_directories` and `cxx11 target_compile features` in `RTF_dll` `RTF_ruby` `RTF_lua` `RTF_python`.
Moreover it adds the `cmake` macro `rtf_add_plugin`.

Please review code.