### PR TITLE
Invert logic of RTF_*_IF macros

### DIFF
--- a/doc/release/v1_4_0.md
+++ b/doc/release/v1_4_0.md
@@ -13,6 +13,9 @@ Important Changes
   compatibility.
 * Added `target_include_directories` in all RTF
   libraries.
+* Change logic for `RTF_*_IF(condition, message)` 
+  functions, adding new functions `RTF_*_IF_TRUE`
+  and `RTF_*_IF_FALSE`, deprecating the old ones.
 
 ### Libraries
 

--- a/examples/plugin/MyTest.cpp
+++ b/examples/plugin/MyTest.cpp
@@ -34,8 +34,8 @@ void MyTest::tearDown() {
 
 void MyTest::run() {
     RTF_TEST_REPORT("testing integers");
-    RTF_TEST_FAIL_IF(2<3, "is not smaller");
+    RTF_TEST_FAIL_IF_FALSE(2<3, "is not smaller");
     int a = 5;
     int b = 3;
-    RTF_TEST_FAIL_IF(a<b, Asserter::format("%d is not smaller than %d.", a, b));
+    RTF_TEST_FAIL_IF_FALSE(a<b, Asserter::format("%d is not smaller than %d.", a, b));
 }

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -40,7 +40,7 @@ public:
         RTF_TEST_CHECK(2==3, "two is equal to three");
         int a = 5;
         int b = 3;
-        RTF_TEST_FAIL_IF(a<b, Asserter::format("%d is not smaller than %d.", a, b));
+        RTF_TEST_FAIL_IF_FALSE(a<b, Asserter::format("%d is not smaller than %d.", a, b));
     }
 
 };

--- a/examples/simple_collector.cpp
+++ b/examples/simple_collector.cpp
@@ -25,7 +25,7 @@ public:
 
     virtual void run() {
         RTF_TEST_REPORT("testing smaller");
-        RTF_TEST_FAIL_IF(3<5, "is not smaller");
+        RTF_TEST_FAIL_IF_FALSE(3<5, "is not smaller");
     }
 };
 
@@ -35,7 +35,7 @@ public:
 
     virtual void run() {
         RTF_TEST_REPORT("testing equality");
-        RTF_TEST_FAIL_IF(5==3, "are not equal");
+        RTF_TEST_FAIL_IF_FALSE(5==3, "are not equal");
     }
 };
 

--- a/examples/simple_fixture.cpp
+++ b/examples/simple_fixture.cpp
@@ -25,7 +25,7 @@ public:
 
     virtual void run() {
         RTF_TEST_REPORT("testing smaller");
-        RTF_TEST_FAIL_IF(3<5, "is not smaller");
+        RTF_TEST_FAIL_IF_FALSE(3<5, "is not smaller");
     }
 };
 
@@ -35,7 +35,7 @@ public:
 
     virtual void run() {
         RTF_TEST_REPORT("testing equality");
-        RTF_TEST_FAIL_IF(3==3, "are not equal");
+        RTF_TEST_FAIL_IF_FALSE(3==3, "are not equal");
     }
 };
 

--- a/examples/simple_runner.cpp
+++ b/examples/simple_runner.cpp
@@ -38,8 +38,8 @@ public:
     virtual void run() {
 
         RTF_TEST_REPORT("testing integers");
-        RTF_TEST_FAIL_IF(2<3, "is not smaller");
-        RTF_TEST_FAIL_IF(5<3, "is not smaller");
+        RTF_TEST_FAIL_IF_FALSE(2<3, "is not smaller");
+        RTF_TEST_FAIL_IF_FALSE(5<3, "is not smaller");
     }
 
 };

--- a/examples/simple_suite.cpp
+++ b/examples/simple_suite.cpp
@@ -24,7 +24,7 @@ public:
 
     virtual void run() {
         RTF_TEST_REPORT("testing smaller");
-        RTF_TEST_FAIL_IF(3<5, "is not smaller");
+        RTF_TEST_FAIL_IF_FALSE(3<5, "is not smaller");
     }
 };
 
@@ -34,7 +34,7 @@ public:
 
     virtual void run() {
         RTF_TEST_REPORT("testing equality");
-        RTF_TEST_FAIL_IF(5==3, "are not equal");
+        RTF_TEST_FAIL_IF_FALSE(5==3, "are not equal");
     }
 };
 

--- a/examples/simple_web.cpp
+++ b/examples/simple_web.cpp
@@ -37,7 +37,7 @@ public:
             int a = rand() % 10;
             int b = rand() % 10;
             RTF_TEST_REPORT("testing smaller...");
-            RTF_TEST_FAIL_IF(a<b, "is not smaller");
+            RTF_TEST_FAIL_IF_FALSE(a<b, "is not smaller");
 #ifdef _WIN32
             Sleep(1000);
 #else
@@ -57,7 +57,7 @@ public:
             int a = rand() % 10;
             int b = rand() % 10;
             RTF_TEST_REPORT("testing equality...");
-            RTF_TEST_FAIL_IF(a==b, "are not equal");
+            RTF_TEST_FAIL_IF_FALSE(a==b, "are not equal");
 #ifdef _WIN32
             Sleep(1000);
 #else

--- a/src/plugins/ada/src_cpp/AdaTest.cpp
+++ b/src/plugins/ada/src_cpp/AdaTest.cpp
@@ -50,12 +50,12 @@ public:
 PREPARE_PLUGIN(AdaTest);
 
 extern "C" void rtf_test_setname(char* name) {
-    RTF_ASSERT_ERROR_IF(testInstance, "testInstance is surprisingly NULL!");
+    RTF_ASSERT_ERROR_IF_FALSE(testInstance, "testInstance is surprisingly NULL!");
     ((AdaTest*)testInstance)->setTestName(name);
 }
 
 extern "C" void rtf_test_report(char* message) {
-    RTF_ASSERT_ERROR_IF(testInstance, "testInstance is surprisingly NULL!");
+    RTF_ASSERT_ERROR_IF_FALSE(testInstance, "testInstance is surprisingly NULL!");
     RTF::Asserter::report(RTF::TestMessage("reports",
                                             message,
                                             RTF_SOURCEFILE(),
@@ -64,7 +64,7 @@ extern "C" void rtf_test_report(char* message) {
 
 
 extern "C" void rtf_test_check(unsigned int condtion, char* message) {
-    RTF_ASSERT_ERROR_IF(testInstance, "testInstance is surprisingly NULL!");
+    RTF_ASSERT_ERROR_IF_FALSE(testInstance, "testInstance is surprisingly NULL!");
     RTF::Asserter::testCheck(condtion != 0, RTF::TestMessage("checks",
                                             message,
                                             RTF_SOURCEFILE(),
@@ -73,7 +73,7 @@ extern "C" void rtf_test_check(unsigned int condtion, char* message) {
 
 
 extern "C" void rtf_test_fail_if(unsigned int condtion, char* message) {
-    RTF_ASSERT_ERROR_IF(testInstance, "testInstance is surprisingly NULL!");
+    RTF_ASSERT_ERROR_IF_FALSE(testInstance, "testInstance is surprisingly NULL!");
     RTF::Asserter::testFail(condtion != 0, RTF::TestMessage("checking condition",
                                             message,
                                             RTF_SOURCEFILE(),

--- a/src/plugins/lua/src/LuaPluginLoader.cpp
+++ b/src/plugins/lua/src/LuaPluginLoader.cpp
@@ -211,7 +211,7 @@ int LuaPluginLoaderImpl::setName(lua_State* L) {
         }
         LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
-        RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+        RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
         owner->setTestName(cst);
     }
     return 0;
@@ -228,7 +228,7 @@ int LuaPluginLoaderImpl::assertError(lua_State* L) {
         }
         LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
-        RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+        RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
         RTF::Asserter::error(RTF::TestMessage("asserts error with exception",
                                               cst, owner->getFileName(), 0));
     }
@@ -246,7 +246,7 @@ int LuaPluginLoaderImpl::assertFail(lua_State* L) {
         }
         LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
-        RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+        RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
         RTF::Asserter::fail(RTF::TestMessage("asserts failure with exception",
                                               cst, owner->getFileName(), 0));
     }
@@ -264,7 +264,7 @@ int LuaPluginLoaderImpl::testReport(lua_State* L) {
         }
         LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
-        RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+        RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
         RTF::Asserter::report(RTF::TestMessage("reports",
                                                cst, owner->getFileName(), 0), (TestCase*)owner);
     }
@@ -283,7 +283,7 @@ int LuaPluginLoaderImpl::testFail(lua_State* L) {
         }
         LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
-        RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+        RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
         RTF::Asserter::testFail(false, RTF::TestMessage("checking ("+string(cond)+")",
                                                cst, owner->getFileName(), 0), (TestCase*)owner);
     }
@@ -302,7 +302,7 @@ int LuaPluginLoaderImpl::testCheck(lua_State* L) {
         }
         LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
         lua_pop(L, 1);
-        RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+        RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
         RTF::Asserter::testCheck(cond, RTF::TestMessage("checks",
                                                cst, owner->getFileName(), 0), (TestCase*)owner);
     }
@@ -318,7 +318,7 @@ int LuaPluginLoaderImpl::getTestEnvironment(lua_State* L) {
     }
     LuaPluginLoaderImpl* owner = static_cast<LuaPluginLoaderImpl*>(lua_touserdata(L, -1));
     lua_pop(L, 1);
-    RTF_ASSERT_ERROR_IF(owner!=NULL, "A null instance of TestCase_Owner");
+    RTF_ASSERT_ERROR_IF_FALSE(owner!=NULL, "A null instance of TestCase_Owner");
     lua_pushstring(L, owner->getEnvironment().c_str());
     return 1;
 }

--- a/src/plugins/python/src/PythonPluginLoader.cpp
+++ b/src/plugins/python/src/PythonPluginLoader.cpp
@@ -287,7 +287,7 @@ PyObject* PythonPluginLoaderImpl::setName(PyObject* self,
     const char* name;
     PythonPluginLoaderImpl* impl =
             (PythonPluginLoaderImpl*) PyCapsule_GetPointer(self, "PythonPluginLoaderImpl");
-    RTF_ASSERT_ERROR_IF(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
+    RTF_ASSERT_ERROR_IF_FALSE(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
     if (!PyArg_ParseTuple(args, "s", &name)) {
         RTF_ASSERT_ERROR(Asserter::format("setName() is called with the wrong paramters."));
     }
@@ -302,7 +302,7 @@ PyObject* PythonPluginLoaderImpl::assertError(PyObject* self,
     const char* message;
     PythonPluginLoaderImpl* impl =
             (PythonPluginLoaderImpl*) PyCapsule_GetPointer(self, "PythonPluginLoaderImpl");
-    RTF_ASSERT_ERROR_IF(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
+    RTF_ASSERT_ERROR_IF_FALSE(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
 
     if (!PyArg_ParseTuple(args, "s", &message)) {
         RTF_ASSERT_ERROR(Asserter::format("assertError() is called with the wrong paramters."));
@@ -319,7 +319,7 @@ PyObject* PythonPluginLoaderImpl::assertFail(PyObject* self,
     const char* message;
     PythonPluginLoaderImpl* impl =
             (PythonPluginLoaderImpl*) PyCapsule_GetPointer(self, "PythonPluginLoaderImpl");
-    RTF_ASSERT_ERROR_IF(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
+    RTF_ASSERT_ERROR_IF_FALSE(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
 
     if (!PyArg_ParseTuple(args, "s", &message)) {
         RTF_ASSERT_ERROR(Asserter::format("assertError() is called with the wrong paramters."));
@@ -335,7 +335,7 @@ PyObject* PythonPluginLoaderImpl::testReport(PyObject* self,
     const char* message;
     PythonPluginLoaderImpl* impl =
             (PythonPluginLoaderImpl*) PyCapsule_GetPointer(self, "PythonPluginLoaderImpl");
-    RTF_ASSERT_ERROR_IF(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
+    RTF_ASSERT_ERROR_IF_FALSE(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
 
     if (!PyArg_ParseTuple(args, "s", &message)) {
         RTF_ASSERT_ERROR(Asserter::format("assertError() is called with the wrong paramters."));
@@ -351,7 +351,7 @@ PyObject* PythonPluginLoaderImpl::testCheck(PyObject* self,
     PyObject* cond;
     PythonPluginLoaderImpl* impl =
             (PythonPluginLoaderImpl*) PyCapsule_GetPointer(self, "PythonPluginLoaderImpl");
-    RTF_ASSERT_ERROR_IF(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
+    RTF_ASSERT_ERROR_IF_FALSE(impl != NULL, "The setName cannot find the instance of PythonPluginLoaderImpl");
 
     if (!PyArg_ParseTuple(args, "Os", &cond, &message)) {
         RTF_ASSERT_ERROR(Asserter::format("assertError() is called with the wrong paramters."));

--- a/src/plugins/ruby/src/RubyPluginLoader.cpp
+++ b/src/plugins/ruby/src/RubyPluginLoader.cpp
@@ -51,7 +51,7 @@ VALUE RubyPluginLoaderImpl::protectedSetup(VALUE testcase, ID id,
     args[1] = id;
     args[2] = param;
     rb_protect(RubyPluginLoaderImpl::wrapSetup, (VALUE)args, &state);
-    RTF_ASSERT_ERROR_IF(state == 0,
+    RTF_ASSERT_ERROR_IF_FALSE(state == 0,
                         Asserter::format("Error in calling setup() within %s because %s",
                                          impl->getFileName().c_str(),
                                          RubyPluginLoaderImpl::getRubyErrorMessage().c_str()));
@@ -73,7 +73,7 @@ VALUE RubyPluginLoaderImpl::protectedRun(VALUE testcase, ID id,
     args[0] = testcase;
     args[1] = id;
     rb_protect(RubyPluginLoaderImpl::wrapRun, (VALUE)args, &state);
-    RTF_ASSERT_ERROR_IF(state == 0,
+    RTF_ASSERT_ERROR_IF_FALSE(state == 0,
                         Asserter::format("Error in calling run() within %s because %s",
                                          impl->getFileName().c_str(),
                                          RubyPluginLoaderImpl::getRubyErrorMessage().c_str()));
@@ -94,7 +94,7 @@ VALUE RubyPluginLoaderImpl::protectedTearDown(VALUE testcase, ID id,
     args[0] = testcase;
     args[1] = id;
     rb_protect(RubyPluginLoaderImpl::wrapTearDown, (VALUE)args, &state);
-    RTF_ASSERT_ERROR_IF(state == 0,
+    RTF_ASSERT_ERROR_IF_FALSE(state == 0,
                         Asserter::format("Error in calling tearDown() within %s because %s",
                                          impl->getFileName().c_str(),
                                          RubyPluginLoaderImpl::getRubyErrorMessage().c_str()));
@@ -180,7 +180,7 @@ void RubyPluginLoaderImpl::run() {
 VALUE RubyPluginLoaderImpl::setName(VALUE self, VALUE obj) {
     char* name = StringValueCStr(obj);
     RubyPluginLoaderImpl* impl = RubyPluginLoaderImpl::getImpFromRuby();
-    RTF_ASSERT_ERROR_IF(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
+    RTF_ASSERT_ERROR_IF_FALSE(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
     impl->setTestName(name);
     return self;
 }
@@ -188,7 +188,7 @@ VALUE RubyPluginLoaderImpl::setName(VALUE self, VALUE obj) {
 VALUE RubyPluginLoaderImpl::assertError(VALUE self, VALUE obj) {
     char* msg = StringValueCStr(obj);
     RubyPluginLoaderImpl* impl = RubyPluginLoaderImpl::getImpFromRuby();
-    RTF_ASSERT_ERROR_IF(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
+    RTF_ASSERT_ERROR_IF_FALSE(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
     RTF::Asserter::error(RTF::TestMessage("asserts error with exception",
                                           msg, impl->getFileName(), 0));
     return self;
@@ -197,7 +197,7 @@ VALUE RubyPluginLoaderImpl::assertError(VALUE self, VALUE obj) {
 VALUE RubyPluginLoaderImpl::assertFail(VALUE self, VALUE obj) {
     char* msg = StringValueCStr(obj);
     RubyPluginLoaderImpl* impl = RubyPluginLoaderImpl::getImpFromRuby();
-    RTF_ASSERT_ERROR_IF(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
+    RTF_ASSERT_ERROR_IF_FALSE(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
     RTF::Asserter::fail(RTF::TestMessage("asserts failure with exception",
                                           msg, impl->getFileName(), 0));
     return self;
@@ -206,7 +206,7 @@ VALUE RubyPluginLoaderImpl::assertFail(VALUE self, VALUE obj) {
 VALUE RubyPluginLoaderImpl::testReport(VALUE self, VALUE obj) {
     char* msg = StringValueCStr(obj);
     RubyPluginLoaderImpl* impl = RubyPluginLoaderImpl::getImpFromRuby();
-    RTF_ASSERT_ERROR_IF(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
+    RTF_ASSERT_ERROR_IF_FALSE(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
     RTF::Asserter::report(RTF::TestMessage("reports",
                                            msg, impl->getFileName(), 0), (TestCase*)impl);
     return self;
@@ -216,7 +216,7 @@ VALUE RubyPluginLoaderImpl::testReport(VALUE self, VALUE obj) {
 VALUE RubyPluginLoaderImpl::testCheck(VALUE self, VALUE cond, VALUE message) {
     char* msg = StringValueCStr(message);
     RubyPluginLoaderImpl* impl = RubyPluginLoaderImpl::getImpFromRuby();
-    RTF_ASSERT_ERROR_IF(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
+    RTF_ASSERT_ERROR_IF_FALSE(impl, "error in RubyPluginLoaderImpl::getImpFromRuby()");
     //std::string str_cond = "false";
     RTF::Asserter::testCheck(RTEST(cond), RTF::TestMessage("checks",
                                            msg, impl->getFileName(), 0), (TestCase*)impl);

--- a/src/rtf/include/rtf/TestAssert.h
+++ b/src/rtf/include/rtf/TestAssert.h
@@ -7,6 +7,25 @@
  *
  */
 
+#if defined(_MSC_VER)
+  // see https://support.microsoft.com/kb/155196/en-us
+  #define __RTF_STR2(x) #x
+  #define __RTF_STR1(x) __RTF_STR2(x)
+  #define __RTF_LOC __FILE__ "("__STR1__(__LINE__)")"
+  #define RTF_COMPILER_MESSAGE(x) __pragma(message(__LOC__ " : msg" #x))
+  #define RTF_COMPILER_WARNING(x) __pragma(message(__LOC__ " : warning msg" #x))
+  #define RTF_COMPILER_ERROR(x)  __pragma(message(__LOC__ " : error msg" #x))
+#elif defined(__GNUC__)
+  // see https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html
+  #define __RTF_DO_PRAGMA(x) _Pragma (#x)
+  #define RTF_COMPILER_MESSAGE(x) __RTF_DO_PRAGMA(message #x)
+  #define RTF_COMPILER_WARNING(x) __RTF_DO_PRAGMA(GCC warning #x)
+  #define RTF_COMPILER_ERROR(x)  __RTF_DO_PRAGMA(GCC error #x)
+#else
+  #define RTF_COMPILER_MESSAGE(x)
+  #define RTF_COMPILER_WARNING(x)
+  #define RTF_COMPILER_ERROR(x)
+#endif
 
 #ifndef _RTF_TESTASSERTER_H
 #define _RTF_TESTASSERTER_H
@@ -25,6 +44,19 @@
                                             RTF_SOURCEFILE(),\
                                             RTF_SOURCELINE())) )
 
+/** Conditional assertion with throwing failure exception.
+ * \ingroup Test Assertions
+ * \param message Message to be reported as the detail of TestMessage
+ * \param condition If this condition evaluates to \c true then the
+ *                  test failed.
+ */
+#define RTF_ASSERT_FAIL_IF_TRUE(condition, message)\
+    ( RTF::Asserter::fail(!condition,\
+                          RTF::TestMessage(std::string("asserts failure on (") +\
+                                           std::string(#condition) + ") with exception",\
+                                           message,\
+                                           RTF_SOURCEFILE(),\
+                                           RTF_SOURCELINE())) )
 
 /** Conditional assertion with throwing failure exception.
  * \ingroup Test Assertions
@@ -32,14 +64,13 @@
  * \param condition If this condition evaluates to \c false then the
  *                  test failed.
  */
-#define RTF_ASSERT_FAIL_IF(condition, message)\
+#define RTF_ASSERT_FAIL_IF_FALSE(condition, message)\
     ( RTF::Asserter::fail(condition,\
                           RTF::TestMessage(std::string("asserts failure on (") +\
                                            std::string(#condition) + ") with exception",\
                                            message,\
                                            RTF_SOURCEFILE(),\
                                            RTF_SOURCELINE())) )
-
 
 /** Assertion with throwing error exception.
  * \ingroup Test Assertions
@@ -51,6 +82,19 @@
                                             RTF_SOURCEFILE(),\
                                             RTF_SOURCELINE())) )
 
+/** Conditional assertion with throwing error exception.
+ * \ingroup Test Assertions
+ * \param message Message to be reported as the detail of TestMessage
+ * \param condition If this condition evaluates to \c true then the
+ *                  test failed.
+ */
+#define RTF_ASSERT_ERROR_IF_TRUE(condition, message)\
+    ( RTF::Asserter::error(!condition,\
+                          RTF::TestMessage(std::string("asserts error on (") +\
+                                           std::string(#condition) + ") with exception",\
+                                           message,\
+                                           RTF_SOURCEFILE(),\
+                                           RTF_SOURCELINE())) )
 
 /** Conditional assertion with throwing error exception.
  * \ingroup Test Assertions
@@ -58,14 +102,13 @@
  * \param condition If this condition evaluates to \c false then the
  *                  test failed.
  */
-#define RTF_ASSERT_ERROR_IF(condition, message)\
+#define RTF_ASSERT_ERROR_IF_FALSE(condition, message)\
     ( RTF::Asserter::error(condition,\
                           RTF::TestMessage(std::string("asserts error on (") +\
                                            std::string(#condition) + ") with exception",\
                                            message,\
                                            RTF_SOURCEFILE(),\
                                            RTF_SOURCELINE())) )
-
 
 /** Reporting a message to the TestResult. RTF_TEST_REPORT does not
  *  throw any exception. It can be used to report any arbitrary message
@@ -82,6 +125,67 @@
                                             RTF_SOURCEFILE(),\
                                             RTF_SOURCELINE()), dynamic_cast<RTF::TestCase*>(this)) )
 
+/** Conditional assertion with throwing failure exception.
+ * \ingroup Test Assertions
+ * \param message Message to be reported as the detail of TestMessage
+ * \param condition If this condition evaluates to \c false then the
+ *                  test failed.
+ */
+#define RTF_ASSERT_FAIL_IF(condition, message) \
+    RTF_COMPILER_WARNING(RTF_ASSERT_FAIL_IF(condition, message) \
+                    is deprecated and will be removed. Please substitute with \
+                    RTF_ASSERT_FAIL_IF_[TRUE|FALSE](condition, message));\
+    RTF_ASSERT_FAIL_IF_FALSE(condition, message)
+
+/** Conditional assertion with throwing error exception.
+ * \ingroup Test Assertions
+ * \param message Message to be reported as the detail of TestMessage
+ * \param condition If this condition evaluates to \c false then the
+ *                  test failed.
+ */
+#define RTF_ASSERT_ERROR_IF(condition, message)\
+    RTF_COMPILER_WARNING(RTF_ASSERT_ERROR_IF(condition, message) \
+                    is deprecated and will be removed. Please substitute with \
+                    RTF_ASSERT_ERROR_IF_[TRUE|FALSE](condition, message));\
+    RTF_ASSERT_ERROR_IF_FALSE(condition, message)
+
+/** Conditional failure report. RTF_TEST_FAIL_IF_FALSE does not throw any
+ *  exception. It reports a failure message to the TestResult indiecating
+ *  that the check on the corresponding condition evaluates to \c false.
+ * \ingroup Test Assertions
+ * \param message Message to be reported as the detail of TestMessage
+ * \param condition If this condition evaluates to \c false then the
+ *                  test failed.
+ *
+ * \note RTF_TEST_FAIL_IF_FALSE throws error exception if it is not called
+ *       within a TestCase class.
+ */
+#define RTF_TEST_FAIL_IF_FALSE(condition, message)\
+    ( RTF::Asserter::testFail(condition,\
+                          RTF::TestMessage(std::string("checking (") +\
+                                           std::string(#condition) + ")",\
+                                           message,\
+                                           RTF_SOURCEFILE(),\
+                                           RTF_SOURCELINE()), dynamic_cast<RTF::TestCase*>(this)) )
+
+/** Conditional failure report. RTF_TEST_FAIL_IF_TRUE does not throw any
+ *  exception. It reports a failure message to the TestResult indiecating
+ *  that the check on the corresponding condition evaluates to \c true.
+ * \ingroup Test Assertions
+ * \param message Message to be reported as the detail of TestMessage
+ * \param condition If this condition evaluates to \c true then the
+ *                  test failed.
+ *
+ * \note RTF_TEST_FAIL_IF_TRUE throws error exception if it is not called
+ *       within a TestCase class.
+ */
+#define RTF_TEST_FAIL_IF_TRUE(condition, message)\
+    ( RTF::Asserter::testFail(!condition,\
+                          RTF::TestMessage(std::string("checking (") +\
+                                           std::string(#condition) + ")",\
+                                           message,\
+                                           RTF_SOURCEFILE(),\
+                                           RTF_SOURCELINE()), dynamic_cast<RTF::TestCase*>(this)) )
 
 /** Conditional failure report. RTF_TEST_FAIL_IF does not throw any
  *  exception. It reports a failure message to the TestResult indiecating
@@ -94,13 +198,12 @@
  * \note RTF_TEST_FAIL_IF throws error exception if it is not called
  *       within a TestCase class.
  */
-#define RTF_TEST_FAIL_IF(condition, message)\
-    ( RTF::Asserter::testFail(condition,\
-                          RTF::TestMessage(std::string("checking (") +\
-                                           std::string(#condition) + ")",\
-                                           message,\
-                                           RTF_SOURCEFILE(),\
-                                           RTF_SOURCELINE()), dynamic_cast<RTF::TestCase*>(this)) )
+#define RTF_TEST_FAIL_IF(condition, message) \
+    RTF_COMPILER_WARNING(RTF_TEST_FAIL_IF(condition, message) \
+                    is deprecated and will be removed. Please substitute with \
+                    RTF_TEST_FAIL_IF[TRUE|FALSE](condition, message));\
+    RTF_TEST_FAIL_IF_FALSE(condition, message)
+
 
 /** RTF_TEST_CHECK combines RTF_TEST_REPORT and RTF_TEST_FAIL_IF.
  * It does not throw any exception. It always reports the message (comment)

--- a/tests/api/AsserterTest.cpp
+++ b/tests/api/AsserterTest.cpp
@@ -77,7 +77,7 @@ public:
             Asserter::fail(false, TestMessage("FALSE"));
         }
         catch(RTF::TestFailureException& e) {
-            RTF_TEST_FAIL_IF(std::string(e.what())==std::string("FALSE"), "exception message");
+            RTF_TEST_FAIL_IF_FALSE(std::string(e.what())==std::string("FALSE"), "exception message");
         }
         catch(std::exception& e) {
             RTF_ASSERT_FAIL("Got wrong exception std::exception");
@@ -89,7 +89,7 @@ public:
             Asserter::error(false, TestMessage("FALSE"));
         }
         catch(RTF::TestErrorException& e) {
-            RTF_TEST_FAIL_IF(std::string(e.what())==std::string("FALSE"), "exception message");
+            RTF_TEST_FAIL_IF_FALSE(std::string(e.what())==std::string("FALSE"), "exception message");
         }
         catch(std::exception& e) {
             RTF_ASSERT_FAIL("Got wrong exception std::exception");

--- a/tests/basic/WebProgListener.cpp
+++ b/tests/basic/WebProgListener.cpp
@@ -84,24 +84,24 @@ public:
         tv.tv_usec = 0;
         setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv,sizeof(struct timeval));
 #endif
-        RTF_ASSERT_FAIL_IF(sockfd >= 0, "opening socket");
+        RTF_ASSERT_FAIL_IF_FALSE(sockfd >= 0, "opening socket");
         server = gethostbyname("localhost");
-        RTF_ASSERT_FAIL_IF(server != nullptr, "no such host");
+        RTF_ASSERT_FAIL_IF_FALSE(server != nullptr, "no such host");
 
         bzero((char *) &serv_addr, sizeof(serv_addr));
         serv_addr.sin_family = AF_INET;
         bcopy((char *)server->h_addr, (char *)&serv_addr.sin_addr.s_addr, server->h_length);
         serv_addr.sin_port = htons(6543);
         RTF_TEST_REPORT("Conneting to the web listener server");
-        RTF_ASSERT_FAIL_IF(connect(sockfd,(struct sockaddr *)
+        RTF_ASSERT_FAIL_IF_FALSE(connect(sockfd,(struct sockaddr *)
                                    &serv_addr,sizeof(serv_addr)) >= 0, "connecting");
 
         char buffer[256] = "GET /status HTTP/1.0\r\n\r\n";
         RTF_TEST_REPORT("Writing to web listener server");
-        RTF_ASSERT_FAIL_IF(write(sockfd, buffer, strlen(buffer)) >= 0, "writing to socket");
+        RTF_ASSERT_FAIL_IF_FALSE(write(sockfd, buffer, strlen(buffer)) >= 0, "writing to socket");
         bzero(buffer,256);
         RTF_TEST_REPORT("Reading from web listener server");
-        RTF_ASSERT_FAIL_IF(read(sockfd,buffer,255) >0, "reading from socket");
+        RTF_ASSERT_FAIL_IF_FALSE(read(sockfd,buffer,255) >0, "reading from socket");
 
         std::stringstream ssbuff(buffer);
         std::string line;

--- a/tests/fixture/FixturePluginLoader.cpp
+++ b/tests/fixture/FixturePluginLoader.cpp
@@ -71,7 +71,7 @@ public:
         RTF_TEST_REPORT(Asserter::format("Loading the fixture manager plugin (%s)", fixtureFilename.c_str()));
         DllFixturePluginLoader* loader = new DllFixturePluginLoader();
         FixtureManager* fixture = loader->open(fixtureFilename);
-        RTF_ASSERT_FAIL_IF(fixture, loader->getLastError());
+        RTF_ASSERT_FAIL_IF_FALSE(fixture, loader->getLastError());
 
         suite.addFixtureManager(fixture);
         suite.addTest(&test1);

--- a/tests/fixture/FixturePluginLoader.cpp
+++ b/tests/fixture/FixturePluginLoader.cpp
@@ -76,7 +76,7 @@ public:
         suite.addFixtureManager(fixture);
         suite.addTest(&test1);
 
-        RTF_TEST_FAIL_IF(fixture->getDispatcher() == (RTF::FixtureEvents*)(&suite), "FixtureEvents dispatcher is not set");
+        RTF_TEST_FAIL_IF_FALSE(fixture->getDispatcher() == (RTF::FixtureEvents*)(&suite), "FixtureEvents dispatcher is not set");
         fixture->setParam("MY_FIXTURE_TEST_PARAM");
 
         // create a test runner

--- a/tests/fixture/FixturePluginLoader.cpp
+++ b/tests/fixture/FixturePluginLoader.cpp
@@ -49,7 +49,7 @@ public:
 
     virtual bool setup(int argc, char**argv)  {
         RTF_TEST_REPORT(Asserter::format("argc %d", argc));
-        RTF_ASSERT_ERROR_IF(argc >= 1, "missing fixture filename in the paramater");
+        RTF_ASSERT_ERROR_IF_FALSE(argc >= 1, "missing fixture filename in the paramater");
         fixtureFilename = argv[1];
         RTF_TEST_REPORT(fixtureFilename);
         return true;

--- a/tests/fixture/MyFixManager.cpp
+++ b/tests/fixture/MyFixManager.cpp
@@ -20,22 +20,22 @@ using namespace RTF;
 PREPARE_FIXTURE_PLUGIN(MyFixManager)
 
 bool MyFixManager::setup(int argc, char** argv) {
-    RTF_ASSERT_ERROR_IF(argc >= 1, "missing paramter MY_FIXTURE_TEST_PARAM");
-    RTF_ASSERT_ERROR_IF(string(argv[0]) == string("MY_FIXTURE_TEST_PARAM"), "missing paramter MY_FIXTURE_TEST_PARAM");
-    RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_SETUP=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_SETUP");
+    RTF_ASSERT_ERROR_IF_FALSE(argc >= 1, "missing paramter MY_FIXTURE_TEST_PARAM");
+    RTF_ASSERT_ERROR_IF_FALSE(string(argv[0]) == string("MY_FIXTURE_TEST_PARAM"), "missing paramter MY_FIXTURE_TEST_PARAM");
+    RTF_ASSERT_ERROR_IF_FALSE(putenv((char*)"MY_FIXTURE_TEST_SETUP=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_SETUP");
     return true;
 }
 
 bool MyFixManager::check() {
-    RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_CHECK=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_CHECK");
+    RTF_ASSERT_ERROR_IF_FALSE(putenv((char*)"MY_FIXTURE_TEST_CHECK=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_CHECK");
     return true;
 }
 
 void MyFixManager::tearDown() {
     getDispatcher()->fixtureCollapsed(TestMessage("COLAPSED"));
-    RTF_ASSERT_ERROR_IF(putenv((char*)"MY_FIXTURE_TEST_TEARDOWN=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_TEARDOWN");
+    RTF_ASSERT_ERROR_IF_FALSE(putenv((char*)"MY_FIXTURE_TEST_TEARDOWN=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_TEARDOWN");
 }
 
 MyFixManager::~MyFixManager() {
-    // RTF_ASSERT_ERROR_IF(putenv("MY_FIXTURE_TEST_DELETE=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_DELETE");
+    // RTF_ASSERT_ERROR_IF_FALSE(putenv("MY_FIXTURE_TEST_DELETE=OK") == 0, "cannot set env variable MY_FIXTURE_TEST_DELETE");
 }

--- a/tests/lua/LuaPlugin.cpp
+++ b/tests/lua/LuaPlugin.cpp
@@ -26,10 +26,10 @@ public:
     LuaPlugin() : TestCase("LuaPlugin") {}
 
     virtual bool setup(int argc, char**argv) {
-        RTF_ASSERT_ERROR_IF(argc>=2, "Missing lua test file as argument");
+        RTF_ASSERT_ERROR_IF_FALSE(argc>=2, "Missing lua test file as argument");
         RTF_TEST_REPORT(Asserter::format("Loading lua file %s", argv[1]));
         test = loader.open(argv[1]);
-        RTF_ASSERT_ERROR_IF(test!=NULL, Asserter::format("Cannot load %s", argv[1]));
+        RTF_ASSERT_ERROR_IF_FALSE(test!=NULL, Asserter::format("Cannot load %s", argv[1]));
         return true;
     }
 

--- a/tests/python/PythonPlugin.cpp
+++ b/tests/python/PythonPlugin.cpp
@@ -26,10 +26,10 @@ public:
     PythonPlugin() : TestCase("PythonPlugin") {}
 
     virtual bool setup(int argc, char**argv) {
-        RTF_ASSERT_ERROR_IF(argc>=2, "Missing python test file as argument");
+        RTF_ASSERT_ERROR_IF_FALSE(argc>=2, "Missing python test file as argument");
         RTF_TEST_REPORT(Asserter::format("Loading python file %s", argv[1]));
         test = loader.open(argv[1]);
-        RTF_ASSERT_ERROR_IF(test!=NULL, Asserter::format("Cannot load %s", argv[1]));
+        RTF_ASSERT_ERROR_IF_FALSE(test!=NULL, Asserter::format("Cannot load %s", argv[1]));
         return true;
     }
 

--- a/tests/ruby/RubyPlugin.cpp
+++ b/tests/ruby/RubyPlugin.cpp
@@ -26,10 +26,10 @@ public:
     RubyPlugin() : TestCase("RubyPlugin") {}
 
     virtual bool setup(int argc, char**argv) {
-        RTF_ASSERT_ERROR_IF(argc>=2, "Missing ruby test file as argument");
+        RTF_ASSERT_ERROR_IF_FALSE(argc>=2, "Missing ruby test file as argument");
         RTF_TEST_REPORT(Asserter::format("Loading ruby file %s", argv[1]));
         test = loader.open(argv[1]);
-        RTF_ASSERT_ERROR_IF(test!=NULL, Asserter::format("Cannot load %s", argv[1]));
+        RTF_ASSERT_ERROR_IF_FALSE(test!=NULL, Asserter::format("Cannot load %s", argv[1]));
         return true;
     }
 


### PR DESCRIPTION
Change logic for RTF_dosomething_IF(condition, message) macros, adding new macros RTF_dosomething_IF_TRUE and RTF_dosomething_IF_FALSE, deprecating the old ones with a warning message.