### PR TITLE
Updated SharedLibraryClassApi.h

### DIFF
--- a/src/plugins/dll/include/rtf/dll/SharedLibraryClassApi.h
+++ b/src/plugins/dll/include/rtf/dll/SharedLibraryClassApi.h
@@ -73,7 +73,7 @@ extern "C" {
         if (!bn) delete cn; \
         return static_cast<void *>(bn); \
     } \
-    SHLIBPP_SHARED_CLASS_FN void factoryname ## _destroy (void *obj) { delete dynamic_cast<classname *>(static_cast<basename *>(obj)); } \
+    SHLIBPP_SHARED_CLASS_FN void factoryname ## _destroy (void *obj) { classname *cn = dynamic_cast<classname *>(static_cast<basename *>(obj)); if(cn) delete cn; } \
     SHLIBPP_SHARED_CLASS_FN int factoryname ## _getVersion (char *ver, int len) { return 0; } \
     SHLIBPP_SHARED_CLASS_FN int factoryname ## _getAbi (char *abi, int len) { return 0; } \
     SHLIBPP_SHARED_CLASS_FN int factoryname ## _getClassName (char *name, int len) { char cname[] = # classname; strncpy(name, cname, len); return strlen(cname)+1; } \


### PR DESCRIPTION
This commit keeps the SharedLibraryClassApi.h file in RTF up to date with the yarp one, after it was modified in order to fix coverity issues.