### PR TITLE
Fix backward compatibility with version 1.2

### DIFF
--- a/src/rtf/CMakeLists.txt
+++ b/src/rtf/CMakeLists.txt
@@ -29,6 +29,7 @@ if(ENABLE_WEB_LISTENER)
         include/rtf/TestResultCollector.h
         include/rtf/TestResult.h
         include/rtf/TestRunner.h
+        include/rtf/TestSuit.h
         include/rtf/TestSuite.h
         include/rtf/TextOutputter.h
         include/rtf/WebProgressListener.h)

--- a/src/rtf/include/rtf/Asserter.h
+++ b/src/rtf/include/rtf/Asserter.h
@@ -16,6 +16,9 @@
 #include <rtf/TestCase.h>
 #include <rtf/TestSuite.h>
 
+// TODO(traversaro): For backcompatibility 1.2 --> 1.4 . To be removed in 1.6
+#include <rtf/TestSuit.h>
+
 #if defined _MSC_VER && _MSC_VER <= 1800 //Visual Studio 12 or earlier has not [[noreturn]]
 #  define RTF_NORETURN __declspec(noreturn)
 #else

--- a/src/rtf/include/rtf/TestSuit.h
+++ b/src/rtf/include/rtf/TestSuit.h
@@ -1,0 +1,21 @@
+// -*- mode:C++; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+/*
+ * Copyright (C) 2015 iCub Facility
+ * Authors: Ali Paikan
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+
+#ifndef _RTF_TESTSUIT_H
+#define _RTF_TESTSUIT_H
+
+#include <rtf/TestSuite.h>
+
+namespace RTF
+{
+    typedef TestSuite TestSuit;
+}
+
+#endif // _RTF_TESTSUIT_H


### PR DESCRIPTION
I avoided inserting a warning because the backward compatibility header
is included also in Asserter.h , however I think that this solution
is better than breacking the compatibility.
I think we can remove then the include for version 1.6 (i.e. current master)